### PR TITLE
chore(repo): add contributing workflow and templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,75 @@
+name: Bug report
+description: Something isn’t behaving as expected
+title: "bug: "
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report this.
+
+        If you can include a repro, you’ll make `pnpm verify` very happy.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Describe the issue and what you expected to happen instead.
+      placeholder: "When I render ScreenFrame at 4K…"
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: Provide minimal steps so we can reproduce reliably.
+      placeholder: |
+        1. Go to …
+        2. Click …
+        3. Observe …
+    validations:
+      required: true
+
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence
+      description: Screenshots, recordings, console logs, stack traces.
+    validations:
+      required: false
+
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, Node version, pnpm version, browser (if applicable).
+      placeholder: "Windows 11, Node 20.x, pnpm 10.x, Chrome 121"
+    validations:
+      required: false
+
+  - type: dropdown
+    id: affected-area
+    attributes:
+      label: Affected area
+      options:
+        - apps/client (demo site)
+        - libs/shadcnui-signage (signage components)
+        - libs/shadcnui / shadcnui-blocks
+        - tooling / CI
+        - docs
+        - not sure
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Pre-flight checks
+      options:
+        - label: I searched existing issues
+          required: true
+        - label: I included repro steps
+          required: true
+        - label: I’m happy for maintainers to edit this issue for clarity
+          required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions / Discussion
+    url: https://github.com/CambridgeMonorail/TheSignAge/discussions
+    about: "Not sure it's a bug? Start here. (Screens are patient; humans less so.)"
+  - name: Documentation Index
+    url: https://github.com/CambridgeMonorail/TheSignAge/tree/main/docs
+    about: "Browse guides and project context."

--- a/.github/ISSUE_TEMPLATE/docs_request.yml
+++ b/.github/ISSUE_TEMPLATE/docs_request.yml
@@ -1,0 +1,37 @@
+name: Documentation request
+description: Suggest an improvement to docs or examples
+title: "docs: "
+labels: [documentation]
+body:
+  - type: textarea
+    id: what
+    attributes:
+      label: What should be improved?
+      description: Tell us what’s missing/confusing or what you’d like to see.
+    validations:
+      required: true
+
+  - type: textarea
+    id: where
+    attributes:
+      label: Where is it?
+      description: Link to the doc(s) or section(s), if known.
+      placeholder: "docs/guides/creating-signage-content.md"
+    validations:
+      required: false
+
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested wording or outline
+      description: Optional, but very helpful.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Pre-flight checks
+      options:
+        - label: I searched existing issues
+          required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,54 @@
+name: Feature request
+description: Propose an improvement or new capability
+title: "feat: "
+labels: [enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Feature requests are welcome.
+
+        Bonus points for signage-specific context: distance readability, fixed aspect ratios, 24/7 operation.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / Use-case
+      description: What are you trying to achieve? What’s the signage scenario?
+      placeholder: "We need a deterministic KPI grid that…"
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What do you think we should build/change?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any other approaches you’ve tried or considered?
+    validations:
+      required: false
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Additional context
+      description: Links, screenshots, sketches, references.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Pre-flight checks
+      options:
+        - label: I searched existing issues
+          required: true
+        - label: This is not a security report (those belong in SECURITY.md)
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,33 @@
+# Pull Request
+
+## Summary
+
+What does this PR change, and why?
+
+## Related
+
+- Issue: #
+- Docs: (link)
+
+## Verification
+
+- [ ] `pnpm verify`
+
+Paste relevant output (or describe what ran):
+
+```text
+
+```
+
+## UI Evidence (if applicable)
+
+- [ ] Screenshots / recording attached
+- [ ] Notes on accessibility considerations (keyboard, focus order, ARIA)
+
+## Notes for Reviewers
+
+Anything you’d like reviewers to focus on?
+
+---
+
+Gentle reminder: signage is software, and software is best served with tests.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -72,16 +72,20 @@ This repository serves as:
 
 ## Technology Stack
 
-- **React** 19.0.0 - Latest stable
-- **TypeScript** 5.9.3 - Strict mode
-- **Nx** 22.4.1 - Monorepo management
-- **Vite** 7.1.3 - Build tool
-- **Vitest** 4.0.0 - Unit testing
-- **Playwright** 1.55.1 - E2E testing
-- **Tailwind CSS** 4.1.18 - Utility-first CSS (v4 with CSS-first config)
-- **shadcn/ui** - Latest component library
-- **Storybook** 10.2.0 - Component documentation
-- **pnpm** 10.27.2 - Package manager
+- **React** (major version pinned in `package.json`)
+- **TypeScript** (strict mode)
+- **Nx** (monorepo tooling)
+- **Vite** (build/dev)
+- **Vitest** + **Testing Library** (unit/component tests)
+- **Playwright** (E2E tests)
+- **Tailwind CSS v4** + **shadcn/ui** (UI)
+- **Storybook** (component docs)
+- **pnpm** (package manager)
+
+Source of truth for exact versions:
+
+- `package.json`
+- `pnpm-lock.yaml`
 
 ## App-Specific Rules
 
@@ -94,6 +98,39 @@ Currently available:
 - Testing and quality workflows (`testing-and-quality.instructions.md`)
 - UI and accessibility patterns (`ui-and-accessibility.instructions.md`)
 - Style guide compliance for demo website (`style-guide-compliance.instructions.md`)
+
+## Contributing Workflow (GitHub)
+
+When contributing to this repository, follow this workflow (and guide others to do the same):
+
+1. **Start with an issue**
+  - Use the issue templates in `.github/ISSUE_TEMPLATE/`.
+  - Bugs should include repro steps + evidence; feature requests should include signage context (1080p/4K, distance readability, always-on).
+  - For vulnerabilities: do **not** open a public issue; follow `SECURITY.md`.
+
+2. **Create a branch (no direct pushes to `main`)**
+  - `main` should be protected; changes land via pull requests.
+  - Use a clear branch name like `feat/<topic>` or `fix/<topic>`.
+
+3. **Implement with repo conventions**
+  - Strict TypeScript; avoid `any`.
+  - Prefer small, focused diffs; avoid broad refactors unless requested.
+  - Keep apps → libs dependency direction (libs never import from apps).
+  - Accessibility is a baseline requirement.
+
+4. **Tests + verification are required**
+  - New features and bug fixes must include tests (Vitest + Testing Library; Playwright for critical flows in `apps/client`).
+  - Run `pnpm verify` before opening the PR.
+  - Use Nx affected scripts when available: `pnpm run lint:affected`, `pnpm run type-check:affected`, `pnpm run test:affected`, `pnpm run build:affected`.
+
+5. **Open a PR using the template**
+  - Follow `.github/PULL_REQUEST_TEMPLATE.md`.
+  - Link related issues (e.g. `Closes #123`).
+  - Include UI evidence (screenshots/recording) for visual changes.
+
+6. **Community standards**
+  - Be kind and constructive; follow `CODE_OF_CONDUCT.md`.
+  - If something is unclear, ask rather than guessing (screens are patient; reviewers less so).
 
 ## Design Philosophy
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,49 @@
+# Code of Conduct
+
+## Our pledge
+
+We want **The Sign Age** to be a welcoming, inclusive place to learn, build, and collaborate.
+
+That means:
+
+- Treat people with respect
+- Assume good intent, especially in text-only communication
+- Prefer constructive feedback over “gotchas”
+- Keep discussions focused on the work and the ideas
+
+If you’re not sure whether something is okay, err on the side of kindness. (A good rule of thumb: would you want this comment displayed on a lobby screen for a week?)
+
+## Expected behavior
+
+Examples of behavior that helps this project:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Accepting constructive criticism gracefully
+- Focusing on what’s best for the project
+
+## Unacceptable behavior
+
+Examples of unacceptable behavior include:
+
+- Harassment, discrimination, or hate speech
+- Personal attacks or demeaning comments
+- Publishing others’ private information without permission
+- Disruptive behavior in issues, pull requests, or discussions
+
+## Scope
+
+This Code of Conduct applies within all project spaces (issues, pull requests, discussions, and other community channels).
+
+## Reporting and enforcement
+
+If you experience or witness unacceptable behavior:
+
+- Please report it by opening a confidential report via GitHub if available, or by contacting the repository maintainers.
+- If the report is about a security issue, follow the process in [SECURITY.md](SECURITY.md) instead.
+
+Maintainers will review reports and take action they deem appropriate to keep the community safe and constructive.
+
+## Attribution
+
+This policy is inspired by common open source community standards, adapted for this project.

--- a/README.md
+++ b/README.md
@@ -227,6 +227,13 @@ These targets are either [inferred automatically](https://nx.dev/concepts/inferr
 
 Contributions are welcome! Please open an issue or submit a pull request for any changes. For detailed guidelines on how to contribute, see [Contributing](./docs/contributing/CONTRIBUTING.md).
 
+### Contributing / Security / Issues
+
+- Contributing guide: [docs/contributing/CONTRIBUTING.md](./docs/contributing/CONTRIBUTING.md)
+- Code of Conduct: [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md)
+- Security policy: [SECURITY.md](./SECURITY.md)
+- Issues: [github.com/CambridgeMonorail/TheSignAge/issues](https://github.com/CambridgeMonorail/TheSignAge/issues) (bug reports, feature requests, and docs improvements)
+
 ## License
 
 This project is licensed under the MIT License.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,32 @@
+# Security Policy
+
+## Supported versions
+
+This project is in active development. Security fixes are applied to the `main` branch.
+
+## Reporting a vulnerability
+
+If you believe you’ve found a security vulnerability, please **do not** open a public issue.
+
+Preferred reporting method:
+
+1. Use GitHub Security Advisories: go to the repository page → **Security** tab → **Report a vulnerability**.
+
+If the Security tab/reporting workflow isn’t available for some reason:
+
+- Contact the maintainers privately (for example via a GitHub direct message).
+
+## What to include
+
+To help us reproduce and fix the issue quickly:
+
+- A clear description of the vulnerability
+- Steps to reproduce (or a minimal proof-of-concept)
+- Impact assessment (what could an attacker do?)
+- Affected areas (files, routes, packages, configurations)
+
+## Coordinated disclosure
+
+We appreciate coordinated disclosure. We’ll aim to acknowledge your report promptly and work with you on a reasonable timeline for a fix.
+
+Thanks for helping keep The Sign Age safe — unattended screens deserve unattended security.

--- a/docs/contributing/CONTRIBUTING.md
+++ b/docs/contributing/CONTRIBUTING.md
@@ -1,111 +1,96 @@
-# Contributing to RiffRoll
+# Contributing to The Sign Age
 
-Thank you for your interest in contributing to **RiffRoll**! Your contributions help improve the project and support guitarists in their practice journey. This guide provides an overview of the contribution process.
+Thanks for your interest in contributing to **The Sign Age** — a repo that treats digital signage like what it really is: software bolted to a wall.
 
-## Table of Contents
-
-1. [Code of Conduct](#code-of-conduct)
-2. [How to Contribute](#how-to-contribute)
-3. [Setting Up the Project Locally](#setting-up-the-project-locally)
-4. [Guidelines for Issues and Pull Requests](#guidelines-for-issues-and-pull-requests)
-5. [Coding Standards](#coding-standards)
-6. [Commit Message Guidelines](#commit-message-guidelines)
-
----
+Whether you’re fixing a typo, tightening a layout, or adding a signage primitive, we appreciate it. (The screens won’t judge your code. But `pnpm verify` might.)
 
 ## Code of Conduct
 
-Please read and adhere to our [Code of Conduct](CODE_OF_CONDUCT.md). We strive to create a welcoming environment where everyone feels respected and valued.
+Be kind, be constructive, and assume good intent.
 
-## How to Contribute
+Please read and follow our [Code of Conduct](../../CODE_OF_CONDUCT.md).
 
-You can contribute in several ways:
+## Getting Oriented
 
-- **Report bugs** by opening an [issue](https://github.com/CambridgeMonorail/RiffRoll/issues).
-- **Request new features** by starting a discussion on GitHub.
-- **Submit pull requests** for bug fixes, enhancements, or documentation updates.
+- Docs index: [docs/README.md](../README.md)
+- Component library: [libs/shadcnui-signage/README.md](../../libs/shadcnui-signage/README.md)
+- Open issues: [github.com/CambridgeMonorail/TheSignAge/issues](https://github.com/CambridgeMonorail/TheSignAge/issues)
 
-## Setting Up the Project Locally
+## Issues
 
-To set up **RiffRoll** locally:
+If you’re opening an issue:
 
-1. **Fork the repository** on GitHub and clone it:
+- Search first to avoid duplicates
+- For bugs: include clear repro steps + expected vs actual behavior
+- For features: include the signage use-case and constraints (1080p/4K, distance readability, always-on)
+
+## Pull Requests
+
+- Work in a fork and open a PR (direct pushes to `main` should be blocked by branch protection)
+- Keep PRs focused and reviewable
+- Link related issues (e.g. `Closes #123`)
+- Run verification before opening the PR: `pnpm verify`
+- Include evidence for UI changes (screenshots/recording)
+
+## Local Setup
+
+1. Fork the repo and clone your fork:
 
    ```bash
-   git clone https://github.com/CambridgeMonorail/RiffRoll/riffroll.git
-   cd riffroll
-    ```
-
-Install dependencies with pnpm:
-
-   ```bash
-Copy code
-pnpm install
+   git clone https://github.com/YOUR_USERNAME/TheSignAge.git
+   cd TheSignAge
    ```
 
-Start the development server:
+2. Install dependencies:
 
    ```bash
-Copy code
-pnpm nx serve riffroll-app
+   pnpm install
    ```
 
-Ensure everything is working by running the test suite:
+3. Run the demo client:
 
    ```bash
-Copy code
-pnpm nx test
+   pnpm serve:client
    ```
 
-This will allow you to develop and test changes locally before submitting a pull request.
+4. Run Storybook:
 
-## Guidelines for Issues and Pull Requests
+   ```bash
+   pnpm serve:storybook
+   ```
 
-### Issues
+5. Verify everything:
 
-- **Search existing issues** to avoid duplicates.
-- When reporting a bug, include **clear steps to reproduce it**, along with your **environment details**.
-- Feature requests should include a **use case** and, if possible, **examples of how it would benefit users**.
+   ```bash
+   pnpm verify
+   ```
 
-### Pull Requests
+## Coding Conventions
 
-- **Work on a forked repository** and create a **new branch** for each feature or bug fix (e.g., `feature/fretboard-animation` or `fix/tempo-slider`).
-- Provide a **clear title and description** for the PR, describing the purpose and the changes.
-- **Reference related issues** in the description (e.g., `Closes #12`).
-- Ensure all **tests pass** by running `pnpm nx test`.
-- **Tag maintainers or reviewers** if you need help or clarification on your PR.
+- TypeScript strict mode (avoid `any`; prefer `unknown` + type guards)
+- Functional React components only
+- Accessibility baseline: keyboard support, semantic HTML, appropriate ARIA
+- Tests required for new features and bug fixes
 
-## Coding Standards
+Canonical references:
 
-To maintain code quality and readability, please follow these guidelines:
+- [.github/copilot-instructions.md](../../.github/copilot-instructions.md)
+- [AGENTS.md](../../AGENTS.md)
 
-- **Code Formatting**: Run `pnpm format` before submitting to ensure consistent formatting.
-- **Linting**: Fix any lint errors by running `pnpm lint`.
-- **Folder Structure**: Follow the established directory structure in the `libs` and `apps` folders.
-- **Documentation**: Document new components and functions with comments, especially if they add new functionality to the app.
+## Commit Messages
 
-## Commit Message Guidelines
+We use Conventional Commits:
 
-We follow the Conventional Commits specification for commit messages. This format allows easy tracking of changes and helps with versioning.
-
-Structure:
-
-   ```plaintext
-Copy code
+```text
 <type>(<scope>): <description>
-   ```
+```
 
 Examples:
 
-feat(fretboard): add scrolling animation for fretboard
-fix(metronome): correct timing issue at high BPM
-Types include:
+```text
+feat(shadcnui-signage): add restaurant menu layout
+fix(client): correct screen frame aspect ratio
+docs(guides): clarify signage content workflow
+```
 
-feat: A new feature.
-fix: A bug fix.
-docs: Documentation updates.
-style: Code formatting changes, no code logic change.
-refactor: Code changes that neither fix a bug nor add a feature.
-test: Adding or updating tests.
-chore: Maintenance tasks.
-Thank you for contributing to RiffRoll! Every contribution is valuable and helps make the app better for everyone. Happy coding!
+Thanks again — every improvement helps make signage less “PowerPoint in disguise” and more “reliable system”.


### PR DESCRIPTION
Summary
This PR adds the “community health” basics needed before publicizing the repo: clear contribution workflow, templates for issues/PRs, and standard policies for conduct + security reporting.

What’s Included
Updated contributor workflow guidance in CONTRIBUTING.md
Added Code of Conduct: CODE_OF_CONDUCT.md
Added Security policy (private vuln reporting): SECURITY.md
Added issue forms (bug/feature/docs) + template chooser config: ISSUE_TEMPLATE
Added PR template: PULL_REQUEST_TEMPLATE.md
Clarified contributing workflow for Copilot/agents: copilot-instructions.md
Added README pointers to these resources: README.md
Why
We want external contributors to have:

A clear, consistent way to report bugs / request features
An obvious path for PRs (including pnpm verify)
A safe and private channel for security issues
Explicit expectations around behavior and collaboration
How to Test
Docs-only / template changes. Quick sanity checks:

Open the repo’s Issues page and confirm the new issue chooser shows the templates
Open “New Pull Request” and confirm the PR template loads
Verify the links resolve:
Contributing guide → CoC / Security policy
README links → new files