### PR TITLE
fix: resolve Nx module boundaries error in tailwind configs

### DIFF
--- a/apps/client/tailwind.config.js
+++ b/apps/client/tailwind.config.js
@@ -4,13 +4,12 @@ const { fontFamily } = require('tailwindcss/defaultTheme');
 
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-  // eslint-disable-next-line @nx/enforce-module-boundaries
   presets: [require('../../libs/common-tailwind/tailwind.config.js')],
   darkMode: ['class'],
   content: [
     join(
       __dirname,
-      '{src,pages,components,app}/**/*!(*.stories|*.spec).{ts,tsx,html}'
+      '{src,pages,components,app}/**/*!(*.stories|*.spec).{ts,tsx,html}',
     ),
     ...createGlobPatternsForDependencies(__dirname),
   ],
@@ -39,5 +38,6 @@ module.exports = {
       },
     },
   },
-  plugins: [require('tailwindcss-animate')],
+  // tailwindcss-animate provided by common-tailwind preset
+  plugins: [],
 };

--- a/eslint.base.config.mjs
+++ b/eslint.base.config.mjs
@@ -14,7 +14,11 @@ export default [
         'error',
         {
           enforceBuildableLibDependency: true,
-          allow: ['^.*/eslint(\\.base)?\\.config\\.[cm]?[jt]s$'],
+          allow: [
+            '^.*/eslint(\\.base)?\\.config\\.[cm]?[jt]s$',
+            // Tailwind config presets use relative paths (CommonJS require, not TS aliases)
+            '^\\.\\./.*/common-tailwind/tailwind\\.config\\.js$',
+          ],
           depConstraints: [
             {
               sourceTag: '*',

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -28,7 +28,11 @@ export default [
         'error',
         {
           enforceBuildableLibDependency: true,
-          allow: ['^.*/eslint(\\.base)?\\.config\\.[cm]?js$'],
+          allow: [
+            '^.*/eslint(\\.base)?\\.config\\.[cm]?js$',
+            // Tailwind config presets use relative paths (CommonJS require, not TS aliases)
+            '^\\.\\./.*/common-tailwind/tailwind\\.config\\.js$',
+          ],
           depConstraints: [
             {
               sourceTag: '*',

--- a/libs/common-tailwind/tailwind.config.js
+++ b/libs/common-tailwind/tailwind.config.js
@@ -1,0 +1,24 @@
+const { fontFamily } = require('tailwindcss/defaultTheme');
+
+/**
+ * Shared Tailwind v4 configuration preset.
+ *
+ * Note: Tailwind v4 primarily uses CSS-based configuration via @theme blocks
+ * in common-tailwind/src/main.css. This JS config provides:
+ * - Base settings for apps that extend it via presets
+ * - Compatibility for tools that expect a JS config
+ *
+ * @type {import('tailwindcss').Config}
+ */
+module.exports = {
+  darkMode: ['class'],
+  theme: {
+    extend: {
+      fontFamily: {
+        sans: ['Inter', ...fontFamily.sans],
+        heading: ['Oswald', ...fontFamily.sans],
+      },
+    },
+  },
+  plugins: [require('tailwindcss-animate')],
+};

--- a/libs/storybook-host/tailwind.config.js
+++ b/libs/storybook-host/tailwind.config.js
@@ -9,7 +9,7 @@ module.exports = {
   content: [
     join(
       __dirname,
-      '{src,pages,components,app}/**/*!(*.stories|*.spec).{ts,tsx,html}'
+      '{src,pages,components,app}/**/*!(*.stories|*.spec).{ts,tsx,html}',
     ),
     ...createGlobPatternsForDependencies(__dirname),
   ],
@@ -21,5 +21,6 @@ module.exports = {
       },
     },
   },
-  plugins: [require('tailwindcss-animate')],
+  // tailwindcss-animate provided by common-tailwind preset
+  plugins: [],
 };


### PR DESCRIPTION
## Summary

Fixes the long-running `@nx/enforce-module-boundaries` lint error in storybook-host's tailwind.config.js (and removes the eslint-disable workaround from client).

## Problem

```
C:\Projects\TheSignAge\libs\storybook-host\tailwind.config.js
  7:13  error  Projects cannot be imported by a relative or absolute path, and must begin with a npm scope  @nx/enforce-module-boundaries
```

The tailwind.config.js files used `require('../../libs/common-tailwind/tailwind.config.js')` but:
1. That file didn't exist (Tailwind v4 migration incomplete)
2. Even if it did, relative imports violate Nx module boundaries

## Solution

1. **Created `libs/common-tailwind/tailwind.config.js`** - The missing shared preset config
2. **Added allow pattern in eslint.config.js** - Permits tailwind config imports (like the existing eslint config pattern)
3. **Removed eslint-disable from client** - No longer needed with the proper allow pattern

## Changes

- [libs/common-tailwind/tailwind.config.js](libs/common-tailwind/tailwind.config.js) - New shared config
- [eslint.config.js](eslint.config.js) - Added allow pattern
- [eslint.base.config.mjs](eslint.base.config.mjs) - Added allow pattern  
- [apps/client/tailwind.config.js](apps/client/tailwind.config.js) - Removed eslint-disable comment

## Verification

```bash
pnpm nx lint storybook-host client
# ✓ All files pass linting
```