### PR TITLE
fix(client): resolve SPA routing redirect loop on custom domain

### DIFF
--- a/apps/client/public/404.html
+++ b/apps/client/public/404.html
@@ -5,7 +5,9 @@
     <title>WallRun</title>
     <script>
       (function () {
-        var segmentCount = 1;
+        // segmentCount = 0 for root domain (wallrun.dev)
+        // segmentCount = 1 for subdirectory deployment (github.io/repo/)
+        var segmentCount = 0;
         var pathname = window.location.pathname
           .split('/')
           .slice(0, 1 + segmentCount)

--- a/apps/client/public/registry/registry.json
+++ b/apps/client/public/registry/registry.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry.json",
   "name": "shadcnui-signage",
-  "homepage": "https://cambridgemonorail.github.io/WallRun/",
+  "homepage": "https://wallrun.dev/",
   "description": "Digital signage components optimized for distance readability and long-running displays",
   "items": [
     {

--- a/apps/client/src/app/pages/library/Library.tsx
+++ b/apps/client/src/app/pages/library/Library.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@wallrun/shadcnui';
+import { Link } from 'react-router-dom';
 import imageSrc from '../../../assets/images/shad-samples.svg';
 
 const EXTERNAL_LINKS = {
@@ -35,12 +36,12 @@ export function LibraryPage() {
             shadcn/ui
           </a>
           , React 19, and Tailwind v4. See{' '}
-          <button
-            onClick={() => (window.location.href = '/getting-started')}
+          <Link
+            to="/getting-started"
             className="text-foreground hover:underline"
           >
             Getting Started
-          </button>{' '}
+          </Link>{' '}
           for installation.
         </p>
       </div>

--- a/apps/client/src/app/pages/status-board/StatusBoard.tsx
+++ b/apps/client/src/app/pages/status-board/StatusBoard.tsx
@@ -21,6 +21,7 @@ import {
   Input,
 } from '@wallrun/shadcnui';
 import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { Logo } from '@wallrun/shadcnui-blocks';
 import { navigationConfig } from '../../constants/navigationConfig';
 
@@ -71,6 +72,7 @@ const maintenanceSchedule = [
 ];
 
 export function StatusBoardPage() {
+  const navigate = useNavigate();
   const [statusData, setStatusData] = useState([
     { name: 'TRANSMIT', status: 'yellow' },
     { name: 'UNISON', status: 'red' },
@@ -105,9 +107,7 @@ export function StatusBoardPage() {
         </div>
         <Button
           variant="secondary"
-          onClick={() =>
-            (window.location.href = navigationConfig.paths.gallery)
-          }
+          onClick={() => navigate(navigationConfig.paths.gallery)}
         >
           View Gallery
         </Button>

--- a/apps/client/src/app/pages/status-board/StatusBoard.tsx
+++ b/apps/client/src/app/pages/status-board/StatusBoard.tsx
@@ -21,7 +21,7 @@ import {
   Input,
 } from '@wallrun/shadcnui';
 import { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { Logo } from '@wallrun/shadcnui-blocks';
 import { navigationConfig } from '../../constants/navigationConfig';
 
@@ -72,7 +72,6 @@ const maintenanceSchedule = [
 ];
 
 export function StatusBoardPage() {
-  const navigate = useNavigate();
   const [statusData, setStatusData] = useState([
     { name: 'TRANSMIT', status: 'yellow' },
     { name: 'UNISON', status: 'red' },
@@ -105,11 +104,8 @@ export function StatusBoardPage() {
           />
           <h1 className="text-4xl font-bold text-primary">Status Board</h1>
         </div>
-        <Button
-          variant="secondary"
-          onClick={() => navigate(navigationConfig.paths.gallery)}
-        >
-          View Gallery
+        <Button variant="secondary" asChild>
+          <Link to={navigationConfig.paths.gallery}>View Gallery</Link>
         </Button>
       </header>
 


### PR DESCRIPTION
## Summary

Fixes the infinite redirect loop causing URLs like `/getting-started/?/~and~/~and~/~and~...` when navigating on wallrun.dev.

## Root Cause

The `404.html` SPA routing hack had `segmentCount = 1`, which is designed for GitHub Pages subdirectory deployment (`github.io/repo/`). Since wallrun.dev serves from the root domain, this caused:

1. `/getting-started` → 404.html triggered
2. With `segmentCount = 1`, it preserved `/getting-started` as the base path
3. Redirect became `/getting-started/?/` (still a 404!)
4. Each redirect cycle accumulated more `~and~` encoded characters

## Changes

### Commit 1: Fix redirect loop
- **404.html**: Changed `segmentCount` from `1` to `0` for root domain deployment
- **.env**: Fixed `BASE_URL` from `/TheSignAge/` to `/`

### Commit 2: Fix SPA navigation & URLs
- **registry.json**: Updated `homepage` from `github.io` to `wallrun.dev`
- **Library.tsx**: Replaced `window.location.href` with React Router `<Link>`
- **StatusBoard.tsx**: Replaced `window.location.href` with `useNavigate()`

## Why This Matters

Using `window.location.href` for internal navigation bypasses SPA routing, causing full page reloads instead of client-side navigation. This degrades UX and can trigger the 404.html redirect logic unnecessarily.

## Verification

After deployment:
- Navigation to `/getting-started` and back should work without URL corruption
- Internal links should use client-side routing (no full page reload)
- Registry at `wallrun.dev/registry/registry.json` shows correct homepage