### PR TITLE
Refine landing and signage demo presentation

### DIFF
--- a/apps/client/src/app/pages/landing/Landing.spec.tsx
+++ b/apps/client/src/app/pages/landing/Landing.spec.tsx
@@ -27,7 +27,7 @@ describe('LandingPage', () => {
       </BrowserRouter>,
     );
     expect(getAllByText(/Developer First/gi).length).toBeGreaterThan(0);
-    expect(getAllByText(/Generative/gi).length).toBeGreaterThan(0);
+    expect(getAllByText(/Component Library/gi).length).toBeGreaterThan(0);
     expect(getAllByText(/Data Driven/gi).length).toBeGreaterThan(0);
   });
 
@@ -40,7 +40,7 @@ describe('LandingPage', () => {
 
     expect(getByText(/BrightSign Ready/gi)).toBeTruthy();
     expect(getAllByText(/Fixed Canvas/gi).length).toBeGreaterThan(0);
-    expect(getByText(/Distance Readable/gi)).toBeTruthy();
+    expect(getByText(/Player Operations/gi)).toBeTruthy();
   });
 
   it('should make the open source developer-first positioning explicit', () => {
@@ -50,10 +50,8 @@ describe('LandingPage', () => {
       </BrowserRouter>,
     );
 
-    expect(getByText(/open source workspace for developers/gi)).toBeTruthy();
-    expect(
-      getByText(/Read the source, inspect the deployment scripts/gi),
-    ).toBeTruthy();
+    expect(getByText(/open source React workspace/gi)).toBeTruthy();
+    expect(getByText(/inspect the deployment scripts/gi)).toBeTruthy();
     expect(getByText(/Read The Code/gi)).toBeTruthy();
   });
 });

--- a/apps/client/src/app/pages/landing/Landing.tsx
+++ b/apps/client/src/app/pages/landing/Landing.tsx
@@ -5,10 +5,15 @@ import {
   Twitter,
   Rocket,
   Palette,
-  Paintbrush,
   BarChart,
   ChartLine,
   Video,
+  Bot,
+  BookOpen,
+  Boxes,
+  Network,
+  PackageCheck,
+  Wrench,
 } from 'lucide-react';
 
 import logoSrc from '../../../assets/images/wallrun-mark.svg';
@@ -39,21 +44,21 @@ export const LandingPage: FC = () => {
         <HeroSection
           title="Digital Signage as Software."
           subtitle="WallRun.dev"
-          description="Signage is software, and it deserves to be treated that way. Build bespoke, generative experiences for BrightSign players with code, data, and deterministic screen systems."
+          description="WallRun is an AI-accelerated open source React workspace for building real signage: distance-readable components, fixed-aspect layouts, BrightSign packaging, player discovery, and deploy scripts you can inspect and change."
           highlights={[
-            'Developer-first workflows',
-            'Generative screen systems',
-            'Live data surfaces',
-            'BrightSign-ready deploys',
+            'Signage React components',
+            'Copilot agents + portable skills',
+            'BrightSign packaging + deploy',
+            'Player discovery + git-safe config',
           ]}
           image={logoSrc}
           imageAlt="WallRun logo"
           ctaPrimary={{
-            text: 'Get Started',
+            text: 'Start Building',
             onClick: () => navigate('/getting-started'),
           }}
           ctaSecondary={{
-            text: 'View Examples',
+            text: 'See Screen Examples',
             onClick: () => navigate('/gallery'),
           }}
           layout="left"
@@ -63,46 +68,46 @@ export const LandingPage: FC = () => {
       </div>
       <AboutSection
         title="Not Slides. Software."
-        description="WallRun is an open source workspace for developers building custom digital experiences that live on walls. It brings React, fixed-aspect layouts, registry components, and deployment tooling into one deliberate signage workflow."
+        description="WallRun is not a CMS or slide deck builder. It is a working notebook for developers who want complete control over screens that live in physical space, from React components to BrightSign player workflows."
         logos={[
           <Logo
             name="nx"
-            className="w-26 h-26 sm:w-12 sm:h-12"
+            className="h-9 w-9 sm:h-10 sm:w-10"
             key="nx"
             title="Nx"
             ariaLabel="Nx"
           />,
           <Logo
             name="tailwind"
-            className="w-26 h-26 sm:w-12 sm:h-12"
+            className="h-9 w-9 sm:h-10 sm:w-10"
             key="tailwind"
             title="Tailwind CSS"
             ariaLabel="Tailwind CSS"
           />,
           <Logo
             name="shadcn"
-            className="w-26 h-26 sm:w-12 sm:h-12"
+            className="h-9 w-9 sm:h-10 sm:w-10"
             key="shadcn"
             title="Shadcn"
             ariaLabel="Shadcn"
           />,
           <Logo
             name="pnpm"
-            className="w-26 h-26 sm:w-12 sm:h-12"
+            className="h-9 w-9 sm:h-10 sm:w-10"
             key="pnpm"
             title="Pnpm"
             ariaLabel="Pnpm"
           />,
           <Logo
             name="react"
-            className="w-26 h-26 sm:w-12 sm:h-12"
+            className="h-9 w-9 sm:h-10 sm:w-10"
             key="react"
             title="React"
             ariaLabel="React"
           />,
           <Logo
             name="vite"
-            className="w-26 h-26 sm:w-12 sm:h-12"
+            className="h-9 w-9 sm:h-10 sm:w-10"
             key="vite"
             title="Vite"
             ariaLabel="Vite"
@@ -113,7 +118,55 @@ export const LandingPage: FC = () => {
         data-testid="about-section"
       />
       <FeaturesSection
-        title="Made For Screens"
+        title="AI-Accelerated Signage Workspace"
+        features={[
+          {
+            title: 'Copilot Agents',
+            description:
+              'Use signage-aware GitHub Copilot agents for layout, runtime, and BrightSign guidance instead of generic web-page suggestions.',
+            icon: <Bot className="text-[hsl(var(--glow-violet))]" />,
+            className: 'hover:border-[hsl(var(--glow-violet)/0.38)]',
+          },
+          {
+            title: 'Portable Skills',
+            description:
+              'Install reusable SKILL.md workflows for signage layout, animation, distance legibility, BrightSign packaging, and player discovery.',
+            icon: <BookOpen className="text-[hsl(var(--glow-cyan))]" />,
+            className: 'hover:border-[hsl(var(--glow-cyan)/0.34)]',
+          },
+          {
+            title: 'Component Registry',
+            description:
+              'Pull signage components from a shadcn-compatible registry so other React projects can adopt WallRun blocks without copying the repo.',
+            icon: <Boxes className="text-[hsl(var(--glow-green))]" />,
+            className: 'hover:border-[hsl(var(--glow-green)/0.34)]',
+          },
+          {
+            title: 'BrightSign Deploy Tools',
+            description:
+              'Package React player apps with an autorun bootstrap and deploy to BrightSign OS players through repeatable scripts.',
+            icon: <PackageCheck className="text-[hsl(var(--glow-amber))]" />,
+            className: 'hover:border-[hsl(var(--glow-amber)/0.34)]',
+          },
+          {
+            title: 'Player Discovery',
+            description:
+              'Find BrightSign devices on the local network, inspect player details, and keep operational configuration outside version control.',
+            icon: <Network className="text-[hsl(var(--glow-pink))]" />,
+            className: 'hover:border-[hsl(var(--glow-pink)/0.34)]',
+          },
+          {
+            title: 'Tooling Documentation',
+            description:
+              'Explore guides, Storybook, examples, and deployment docs that make the workspace understandable to developers and searchable by topic.',
+            icon: <Wrench className="text-[hsl(var(--glow-violet))]" />,
+            className: 'hover:border-[hsl(var(--glow-violet)/0.38)]',
+          },
+        ]}
+        data-testid="workspace-section"
+      />
+      <FeaturesSection
+        title="What WallRun Gives You"
         features={[
           {
             title: 'Developer First',
@@ -123,9 +176,9 @@ export const LandingPage: FC = () => {
             className: 'hover:border-[hsl(var(--glow-violet)/0.38)]',
           },
           {
-            title: 'Generative',
+            title: 'Component Library',
             description:
-              'Use motion, procedural visuals, and composable React blocks to make displays feel alive without becoming noisy.',
+              'Use signage-specific React primitives, layouts, and blocks designed for distance readability and fixed-format screens.',
             icon: <Palette className="text-[hsl(var(--glow-cyan))]" />,
             className: 'hover:border-[hsl(var(--glow-cyan)/0.34)]',
           },
@@ -144,18 +197,18 @@ export const LandingPage: FC = () => {
             className: 'hover:border-[hsl(var(--glow-amber)/0.34)]',
           },
           {
+            title: 'Player Operations',
+            description:
+              'Discover BrightSign devices on the local network and keep player configuration out of Git while still making deploys repeatable.',
+            icon: <Rocket className="text-[hsl(var(--glow-violet))]" />,
+            className: 'hover:border-[hsl(var(--glow-violet)/0.38)]',
+          },
+          {
             title: 'Fixed Canvas',
             description:
               'Design for known screen sizes and viewing distance first, with deterministic composition over webpage-style flow.',
             icon: <BarChart className="text-[hsl(var(--glow-pink))]" />,
             className: 'hover:border-[hsl(var(--glow-pink)/0.34)]',
-          },
-          {
-            title: 'Distance Readable',
-            description:
-              'High contrast, strong hierarchy, and large typography keep information legible from across the room.',
-            icon: <Paintbrush className="text-[hsl(var(--glow-violet))]" />,
-            className: 'hover:border-[hsl(var(--glow-violet)/0.38)]',
           },
         ]}
         data-testid="features-section"

--- a/apps/client/src/app/pages/signage/AnnouncementsBoard.tsx
+++ b/apps/client/src/app/pages/signage/AnnouncementsBoard.tsx
@@ -53,7 +53,7 @@ export const AnnouncementsBoard: FC = () => {
         variant="pink"
         showGrid={false}
         data-testid="announcements-board"
-        className="bg-gradient-to-br from-indigo-950 via-purple-950 to-pink-950"
+        className="bg-slate-950"
       >
         {/* Additional grid overlay */}
         <div

--- a/apps/client/src/app/pages/signage/EventSchedule.tsx
+++ b/apps/client/src/app/pages/signage/EventSchedule.tsx
@@ -73,12 +73,12 @@ export const EventSchedule: FC = () => {
         variant="violet"
         showGrid={false}
         data-testid="event-schedule"
-        className="bg-gradient-to-br from-violet-950 via-slate-950 to-indigo-950"
+        className="bg-slate-950"
       >
         {/* Additional background effects */}
         <div
           aria-hidden="true"
-          className="absolute inset-0 bg-[radial-gradient(ellipse_at_top,_var(--tw-gradient-stops))] from-violet-900/30 via-transparent to-transparent"
+          className="absolute inset-0 bg-[radial-gradient(ellipse_at_top,_hsl(var(--secondary)_/_0.16),transparent_58%)]"
         />
         <div
           aria-hidden="true"
@@ -109,8 +109,8 @@ export const EventSchedule: FC = () => {
         </div>
 
         <footer className="mt-10 text-center sm:mt-12 lg:mt-16">
-          <div className="inline-block rounded-2xl border border-violet-500/30 bg-gradient-to-r from-violet-600/20 via-fuchsia-600/20 to-violet-600/20 px-5 py-4 backdrop-blur-sm sm:px-8 sm:py-5 lg:px-12 lg:py-6">
-            <p className="text-base text-violet-200 sm:text-lg lg:text-2xl">
+          <div className="inline-block rounded-2xl border border-slate-700/60 bg-slate-900/70 px-5 py-4 backdrop-blur-sm sm:px-8 sm:py-5 lg:px-12 lg:py-6">
+            <p className="text-base text-slate-100 sm:text-lg lg:text-2xl">
               Download the mobile app for personalized schedule and
               notifications
             </p>

--- a/apps/client/src/app/pages/signage/OfficeDirectory.tsx
+++ b/apps/client/src/app/pages/signage/OfficeDirectory.tsx
@@ -32,7 +32,7 @@ export const OfficeDirectory: FC = () => {
 
         <div className="relative z-10 mx-auto max-w-7xl">
           <header className="mb-10 text-center sm:mb-12 lg:mb-16">
-            <h1 className="mb-5 bg-gradient-to-r from-blue-400 via-cyan-300 to-blue-400 bg-clip-text text-5xl font-bold leading-none text-transparent sm:mb-6 sm:text-6xl lg:mb-8 lg:text-8xl">
+            <h1 className="mb-5 text-5xl font-bold leading-none text-cyan-100 sm:mb-6 sm:text-6xl lg:mb-8 lg:text-8xl">
               Office Directory
             </h1>
             <div className="inline-flex items-center gap-3 rounded-full border border-blue-800/50 bg-blue-950/50 px-4 py-3 text-base text-cyan-300 backdrop-blur-sm sm:gap-4 sm:px-6 sm:text-xl lg:px-8 lg:py-4 lg:text-3xl">
@@ -61,7 +61,9 @@ export const OfficeDirectory: FC = () => {
                 </div>
                 <div className="mb-4 h-px bg-gradient-to-r from-blue-500/50 via-cyan-500/50 to-transparent sm:mb-6" />
                 <div className="flex flex-col gap-2 text-lg sm:flex-row sm:items-center sm:justify-between sm:text-xl lg:text-2xl">
-                  <span className="font-semibold text-cyan-300">Room {dir.room}</span>
+                  <span className="font-semibold text-cyan-300">
+                    Room {dir.room}
+                  </span>
                   <span className="font-mono text-blue-300">{dir.phone}</span>
                 </div>
               </div>

--- a/apps/client/src/app/pages/signage/OfficeLobbyLoop.tsx
+++ b/apps/client/src/app/pages/signage/OfficeLobbyLoop.tsx
@@ -76,7 +76,9 @@ export const OfficeLobbyLoop: FC = () => {
                 data-testid="office-lobby-loop-welcome-slide"
               >
                 <div className="rounded-2xl border border-white/10 bg-white/5 p-5 sm:p-6 lg:col-span-7 lg:p-10">
-                  <div className="text-lg text-white/70 sm:text-xl lg:text-2xl">Message</div>
+                  <div className="text-lg text-white/70 sm:text-xl lg:text-2xl">
+                    Message
+                  </div>
                   <div className="mt-3 text-3xl font-semibold tracking-tight sm:text-4xl lg:text-6xl">
                     Welcome to HQ
                   </div>
@@ -86,7 +88,9 @@ export const OfficeLobbyLoop: FC = () => {
                   </div>
                 </div>
                 <div className="rounded-2xl border border-white/10 bg-white/5 p-5 sm:p-6 lg:col-span-5 lg:p-10">
-                  <div className="text-lg text-white/70 sm:text-xl lg:text-2xl">Next update in</div>
+                  <div className="text-lg text-white/70 sm:text-xl lg:text-2xl">
+                    Next update in
+                  </div>
                   <Countdown
                     targetEpochMs={nextUpdateEpochMs}
                     format="mm:ss"
@@ -129,7 +133,9 @@ export const OfficeLobbyLoop: FC = () => {
                   />
                 </div>
                 <div className="rounded-2xl border border-white/10 bg-white/5 p-5 sm:p-6 lg:col-span-5 lg:p-10">
-                  <div className="text-lg text-white/70 sm:text-xl lg:text-2xl">Notes</div>
+                  <div className="text-lg text-white/70 sm:text-xl lg:text-2xl">
+                    Notes
+                  </div>
                   <ul className="mt-4 space-y-3 text-lg text-white/70 sm:text-2xl lg:mt-5 lg:space-y-4 lg:text-3xl">
                     <li>• Fire exits: follow green signage</li>
                     <li>• Quiet zones on Level 2</li>
@@ -147,8 +153,10 @@ export const OfficeLobbyLoop: FC = () => {
                     Connectivity boundary
                   </div>
                   <div className="grid grid-cols-1 gap-4 sm:gap-6 lg:grid-cols-2 lg:gap-8">
-                    <div className="rounded-xl border border-white/10 bg-black/20 p-5 sm:p-6 lg:p-8">
-                      <div className="mb-3 text-lg text-white/70 sm:text-xl lg:mb-4">Healthy</div>
+                    <div className="rounded-xl border border-white/10 bg-slate-950/40 p-5 sm:p-6 lg:p-8">
+                      <div className="mb-3 text-lg text-white/70 sm:text-xl lg:mb-4">
+                        Healthy
+                      </div>
                       <OfflineFallback
                         isOnline={true}
                         isHealthy={true}
@@ -162,7 +170,7 @@ export const OfficeLobbyLoop: FC = () => {
                       </OfflineFallback>
                     </div>
 
-                    <div className="rounded-xl border border-white/10 bg-black/20 p-5 sm:p-6 lg:p-8">
+                    <div className="rounded-xl border border-white/10 bg-slate-950/40 p-5 sm:p-6 lg:p-8">
                       <div className="mb-3 text-lg text-white/70 sm:text-xl lg:mb-4">
                         Unhealthy
                       </div>
@@ -175,7 +183,9 @@ export const OfficeLobbyLoop: FC = () => {
                           </div>
                         }
                       >
-                        <div className="text-2xl font-semibold sm:text-3xl lg:text-4xl">Live data</div>
+                        <div className="text-2xl font-semibold sm:text-3xl lg:text-4xl">
+                          Live data
+                        </div>
                       </OfflineFallback>
                     </div>
                   </div>

--- a/apps/client/src/app/pages/signage/RestaurantMenu.tsx
+++ b/apps/client/src/app/pages/signage/RestaurantMenu.tsx
@@ -85,7 +85,7 @@ export const RestaurantMenu: FC = () => {
                 DAILY SELECTION
               </p>
             </div>
-            <h1 className="mb-4 bg-gradient-to-r from-white via-teal-100 to-white bg-clip-text text-5xl font-bold leading-none text-transparent sm:text-6xl lg:mb-6 lg:text-8xl">
+            <h1 className="mb-4 text-5xl font-bold leading-none text-white sm:text-6xl lg:mb-6 lg:text-8xl">
               Today's Menu
             </h1>
             <p className="text-lg tracking-[0.2em] text-slate-300 sm:text-2xl lg:text-3xl">

--- a/apps/client/src/app/pages/signage/WelcomeScreen.tsx
+++ b/apps/client/src/app/pages/signage/WelcomeScreen.tsx
@@ -32,7 +32,7 @@ export const WelcomeScreen: FC = () => {
 
         <div className="relative z-10 max-w-[22rem] px-4 text-center sm:max-w-4xl sm:px-8 lg:max-w-6xl">
           <div className="mb-8 sm:mb-12">
-            <h1 className="mb-4 bg-gradient-to-r from-blue-400 via-purple-300 to-pink-400 bg-clip-text text-6xl font-bold leading-none tracking-tight text-transparent sm:text-8xl md:text-[8rem] lg:mb-6 lg:text-[12rem] xl:text-[14rem]">
+            <h1 className="mb-4 text-6xl font-bold leading-none tracking-tight text-white sm:text-8xl md:text-[8rem] lg:mb-6 lg:text-[12rem] xl:text-[14rem]">
               Welcome
             </h1>
             <div className="mx-auto mb-8 h-1 w-32 bg-gradient-to-r from-transparent via-purple-400 to-transparent sm:mb-12 sm:w-48 md:w-64" />

--- a/docs/plans/2026-04-30-impeccable-client-audit.md
+++ b/docs/plans/2026-04-30-impeccable-client-audit.md
@@ -1,0 +1,55 @@
+# Impeccable Client Audit
+
+**Date:** 2026-04-30
+**Status:** Complete
+
+## Goal
+
+Try Impeccable against `apps/client` to identify useful design polish
+opportunities without letting it override WallRun's app-scoped design contract.
+
+## Context
+
+WallRun now has scoped design authority:
+
+- `apps/client/DESIGN.md` for the demo app brand
+- `docs/design/STYLE_GUIDE.md` for expanded demo-site rationale
+- `libs/common-tailwind/DESIGN.md` for shared signage-safe defaults
+- `libs/shadcnui-signage/DESIGN.md` for reusable signage components
+
+Impeccable should be used as a reviewer and critique aid, not as a replacement
+source of truth.
+
+## Task Breakdown
+
+- [x] Run an Impeccable audit against `apps/client`.
+- [x] Review findings for compatibility with the WallRun demo design contract.
+- [x] Apply only scoped, low-risk improvements.
+- [x] Run focused validation.
+
+## Completion Notes
+
+Impeccable reported nine anti-patterns in signage demo pages:
+
+- generic purple/cyan gradient surfaces
+- decorative gradient text on large signage headings
+- pure `bg-black/20` translucent panels
+
+Applied only small, scoped cleanups in `apps/client/src/app/pages/signage`.
+The follow-up Impeccable run reported no remaining anti-patterns.
+
+## Files To Change
+
+Unknown until findings are reviewed. Expected scope is `apps/client/**` and
+possibly demo-only landing components consumed by `apps/client`.
+
+## Commands To Run
+
+- `npx impeccable detect apps/client/src`
+- `pnpm run type-check:client`
+
+## Expected Result
+
+A small, reviewable branch with either documented findings or targeted
+improvements that make the demo site feel more polished while preserving the
+current branding and avoiding shared signage theme drift.

--- a/docs/plans/2026-04-30-landing-impeccable-critique.md
+++ b/docs/plans/2026-04-30-landing-impeccable-critique.md
@@ -1,0 +1,59 @@
+# Landing Impeccable Critique
+
+**Date:** 2026-04-30
+**Status:** Complete
+
+## Goal
+
+Use the Impeccable critique workflow to assess whether the landing page
+communicates WallRun's repository value clearly, compellingly, and in a visual
+direction that matches the new demo app brand.
+
+## Context
+
+The landing page now looks much stronger, but the critique should test whether
+the first viewport and page flow clearly explain why a developer should care
+about WallRun:
+
+- signage-specific React components
+- BrightSign packaging and deployment
+- player discovery and git-safe player configuration
+- fixed-aspect, distance-readable display systems
+- not a CMS, not slideware
+
+## Task Breakdown
+
+- [x] Inspect the live landing page at `http://localhost:4200/`.
+- [x] Run Impeccable detection against landing-related source.
+- [x] Compare landing copy against repository value proposition.
+- [x] Apply a small critique-driven improvement pass if clear.
+- [x] Run focused validation.
+
+## Completion Notes
+
+Impeccable's deterministic detector returned no landing anti-patterns. The
+human critique found that the hero looked strong but undersold the concrete repo
+value. The landing copy now names the practical reasons to use WallRun earlier:
+
+- signage-specific React components
+- fixed-aspect screen layouts
+- BrightSign packaging and deployment
+- player discovery and git-safe configuration
+
+The first viewport now communicates both the brand idea and the developer
+workflow more directly.
+
+## Files To Change
+
+- `apps/client/src/app/pages/landing/Landing.tsx`
+- possibly landing component files under `libs/landing/src/lib/components`
+
+## Commands To Run
+
+- `npx impeccable --json apps/client/src/app/pages/landing libs/landing/src/lib/components`
+- `pnpm run type-check:client`
+
+## Expected Result
+
+A clearer landing page that preserves the new visual language while making the
+repo's practical value obvious faster.

--- a/libs/landing/src/lib/components/hero-section/index.tsx
+++ b/libs/landing/src/lib/components/hero-section/index.tsx
@@ -170,7 +170,7 @@ export const HeroSection: FC<HeroSectionProps> = ({
         <span className="hero-aurora__band hero-aurora__band--detail" />
       </div>
       <div className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-[hsl(var(--glow-violet)/0.75)] to-transparent" />
-      <div className="relative mx-auto flex w-full max-w-7xl flex-col-reverse items-center gap-10 px-4 py-16 sm:px-6 md:px-10 lg:min-h-[calc(100vh-3.5rem)] lg:flex-row lg:gap-16 lg:py-20">
+      <div className="relative mx-auto flex w-full max-w-7xl flex-col-reverse items-center gap-10 px-4 py-14 sm:px-6 md:px-10 lg:min-h-[calc(88vh-3.5rem)] lg:flex-row lg:gap-16 lg:py-16">
         <div
           className={`relative z-10 flex-1 space-y-6 text-center lg:text-left ${
             isReversed ? 'order-last lg:order-first' : ''

--- a/libs/shadcnui-blocks/src/lib/components/logo-carousel/index.tsx
+++ b/libs/shadcnui-blocks/src/lib/components/logo-carousel/index.tsx
@@ -1,4 +1,4 @@
-import { FC, ReactElement, useEffect, useState, useRef } from 'react';
+import { FC, ReactElement } from 'react';
 
 export interface LogoCarouselProps {
   logos: ReactElement[];
@@ -13,35 +13,6 @@ export interface LogoCarouselProps {
  * other set of logos in a visually appealing and interactive manner.
  */
 const LogoCarousel: FC<LogoCarouselProps> = ({ logos, header, subheader }) => {
-  const containerRef = useRef<HTMLDivElement>(null);
-  const [carouselLogos, setCarouselLogos] = useState([...logos, ...logos]); // Duplicate logos for seamless scroll
-
-  useEffect(() => {
-    const container = containerRef.current;
-    if (!container) return;
-
-    const scrollStep = 1; // Scroll speed (px per interval)
-    const interval = 16; // Interval duration (~60 FPS)
-    let animationFrame: number;
-
-    const startScrolling = () => {
-      if (!container) return;
-
-      container.scrollLeft += scrollStep;
-
-      // Check if the first logo is fully out of view
-      if (container.scrollLeft >= container.scrollWidth / 2) {
-        container.scrollLeft = 0; // Reset scroll position to maintain seamless loop
-      }
-
-      animationFrame = requestAnimationFrame(startScrolling); // Keep scrolling
-    };
-
-    animationFrame = requestAnimationFrame(startScrolling); // Start the animation
-
-    return () => cancelAnimationFrame(animationFrame); // Cleanup on unmount
-  }, []);
-
   return (
     <div className="flex flex-col items-center justify-center text-center">
       {/* Header Section */}
@@ -50,24 +21,25 @@ const LogoCarousel: FC<LogoCarouselProps> = ({ logos, header, subheader }) => {
           {header}
         </h2>
       )}
-      {subheader && <p className="mt-2 text-sm text-muted-foreground sm:text-base">{subheader}</p>}
+      {subheader && (
+        <p className="mt-2 text-sm text-muted-foreground sm:text-base">
+          {subheader}
+        </p>
+      )}
 
-      {/* Logo Carousel */}
       <div
-        ref={containerRef}
-        className="relative mt-6 w-full overflow-hidden"
-        style={{ height: '100px', whiteSpace: 'nowrap' }}
+        data-testid="logo-grid"
+        className="mt-8 grid w-full grid-cols-2 items-center justify-items-center gap-6 sm:grid-cols-3 lg:grid-cols-6"
       >
-        <div className="flex">
-          {carouselLogos.map((logo, index) => (
-            <div
-              key={`logo-${index}`}
-              className="shrink-0 w-1/4 h-24 flex items-center justify-center"
-            >
-              {logo}
-            </div>
-          ))}
-        </div>
+        {logos.map((logo, index) => (
+          <div
+            key={`logo-${index}`}
+            data-testid={`logo-grid-item-${index}`}
+            className="flex h-16 w-full items-center justify-center rounded-md border border-border/50 bg-background/35 px-4 text-muted-foreground"
+          >
+            {logo}
+          </div>
+        ))}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
Refine the client landing page and signage demo surfaces to better communicate WallRun's developer-facing value and remove low-value visual anti-patterns identified during the critique pass.

## What Changed
- update landing copy to emphasize the AI-accelerated signage workspace, BrightSign tooling, player discovery, and inspectable developer workflows
- add plan notes documenting the impeccable client audit and landing critique passes
- simplify several signage demo backgrounds and headings to reduce decorative gradients and improve clarity
- tighten the shared hero section spacing and replace the landing logo carousel with a static logo grid
- update the landing page spec to match the revised copy

## Verification
- `pnpm verify`

## Notes
This branch includes the completed audit and critique plan documents for the applied changes.