### PR TITLE
Document Storybook theming and align branding

### DIFF
--- a/docs/plans/2026-05-02-storybook-theming-docs.md
+++ b/docs/plans/2026-05-02-storybook-theming-docs.md
@@ -1,0 +1,37 @@
+# Plan: Storybook Theming Docs For shadcnui-signage
+
+## Goal
+
+Add a dedicated top-level Storybook docs page that explains how the current
+shared signage theme works, where the important tokens live, and how consumers
+should customize branding without forking component internals.
+
+## Scope
+
+- add a new top-level MDX docs page in `libs/storybook-host/src`
+- document the current shared token model from `libs/common-tailwind`
+- show the default palette with Storybook docs color blocks
+- include a concrete branded override example
+- link the page from the existing top-level docs flow
+
+## Files
+
+- `libs/storybook-host/src/Theming.mdx`
+- `libs/storybook-host/src/Introduction.mdx`
+- `libs/storybook-host/src/GettingStarted.mdx`
+- `libs/storybook-host/src/BestPractices.mdx`
+- `libs/storybook-host/.storybook/preview.ts`
+
+## Acceptance Criteria
+
+- Storybook has a top-level `Theming` page
+- the page explains the shared theme model and token ownership
+- the page identifies the main customization hooks and source files
+- the page includes a palette section using Storybook docs blocks
+- the page includes a concrete branded override example
+- the existing top-level docs pages reference the theming page
+
+## Validation
+
+- open the new Storybook docs page locally
+- confirm the page renders and the docs navigation order is correct

--- a/libs/common-tailwind/src/styles.d.ts
+++ b/libs/common-tailwind/src/styles.d.ts
@@ -2,3 +2,5 @@ declare module '*.css' {
   const css: string;
   export default css;
 }
+
+declare module 'common-tailwind/storybook';

--- a/libs/storybook-host/.storybook/assets/wallrun-mark.svg
+++ b/libs/storybook-host/.storybook/assets/wallrun-mark.svg
@@ -1,0 +1,7 @@
+<svg viewBox="0 0 64 36" xmlns="http://www.w3.org/2000/svg" aria-label="WallRun mark" role="img">
+  <g fill="#885CF6">
+    <path d="M2 4H17L28 32H13L2 4Z" />
+    <path d="M22 4H37L48 32H33L22 4Z" opacity="0.94" />
+    <path d="M42 4H57L62 17H47L42 4Z" opacity="0.88" />
+  </g>
+</svg>

--- a/libs/storybook-host/.storybook/preview.ts
+++ b/libs/storybook-host/.storybook/preview.ts
@@ -7,6 +7,7 @@ export const parameters = {
       order: [
         'Introduction',
         'Getting Started',
+        'Theming',
         'Best Practices',
         'Resources',
         'Signage',

--- a/libs/storybook-host/.storybook/tsconfig.json
+++ b/libs/storybook-host/.storybook/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "strict": true,
+    "types": ["vite/client"]
+  },
+  "include": ["./*.ts"]
+}

--- a/libs/storybook-host/.storybook/wallrunAltTheme.ts
+++ b/libs/storybook-host/.storybook/wallrunAltTheme.ts
@@ -9,7 +9,7 @@ export default create({
 
   brandTitle: 'WallRun Storybook',
   brandUrl: 'https://cambridgemonorail.github.io/WallRun/',
-  brandImage: './new-logo.svg',
+  brandImage: './wallrun-mark.svg',
   brandTarget: '_self',
 
   //

--- a/libs/storybook-host/.storybook/wallrunTheme.ts
+++ b/libs/storybook-host/.storybook/wallrunTheme.ts
@@ -9,7 +9,7 @@ export default create({
 
   brandTitle: 'WallRun Storybook',
   brandUrl: 'https://cambridgemonorail.github.io/WallRun/',
-  brandImage: './new-logo.svg',
+  brandImage: './wallrun-mark.svg',
   brandTarget: '_self',
 
   //

--- a/libs/storybook-host/src/BestPractices.mdx
+++ b/libs/storybook-host/src/BestPractices.mdx
@@ -57,6 +57,18 @@ Use layouts such as `SignageHeader`, `SplitScreen`, and fixed panels to decide w
 
 The shell should still make sense even if no behaviour is active yet.
 
+## Theme At The Right Layer
+
+Branding decisions should follow the same layering discipline as layout decisions.
+
+Prefer this order:
+
+1. Override shared theme tokens in the consuming app when the whole signage surface should shift.
+2. Use component-level class hooks when one screen needs stronger emphasis than the rest of the app.
+3. Avoid one-off story-level overrides unless the page is deliberately demonstrating customization.
+
+The dedicated `Theming` page explains the current split between shared CSS variables in `common-tailwind` and screen-specific styling hooks in `shadcnui-signage`.
+
 ## 3. Favour Whole Message States Over Dense Fragments
 
 The audience is standing across the room, not scanning a laptop screen.

--- a/libs/storybook-host/src/GettingStarted.mdx
+++ b/libs/storybook-host/src/GettingStarted.mdx
@@ -43,6 +43,8 @@ That distinction matters:
 
 That order keeps the screen stable and makes operational logic easier to reason about.
 
+If you already know the screen shape but need to make it fit a venue or customer brand, read `Theming` before you start adding ad hoc class overrides to stories or pages.
+
 ## Minimal Realistic Example
 
 ```tsx
@@ -131,4 +133,4 @@ If a story reads like a small component test, treat it as API reference, not des
 
 ## Next Steps
 
-Read `Best Practices` after this page, then move into the `Signage` docs in the order suggested on the Introduction page.
+Read `Theming` next if you need to adapt the shared palette or screen chrome for a brand. Read `Best Practices` next if you want guidance on how to structure the screen itself.

--- a/libs/storybook-host/src/Introduction.mdx
+++ b/libs/storybook-host/src/Introduction.mdx
@@ -59,11 +59,12 @@ If you are new to the signage library, read the docs in this order:
 
 1. `Introduction`
 2. `Getting Started`
-3. `Signage/Layouts/SignageContainer`
-4. `Signage/Blocks/FullscreenHero` or `Signage/Blocks/MenuBoard`
-5. `Signage/Behaviour/ContentRotator` and `Signage/Behaviour/OfflineFallback`
+3. `Theming`
+4. `Signage/Layouts/SignageContainer`
+5. `Signage/Blocks/FullscreenHero` or `Signage/Blocks/MenuBoard`
+6. `Signage/Behaviour/ContentRotator` and `Signage/Behaviour/OfflineFallback`
 
-That sequence moves from screen shell, to composition, to operational behaviour.
+That sequence moves from screen shell, to theme ownership, to composition, to operational behaviour.
 
 ## A Typical Screen Assembly
 

--- a/libs/storybook-host/src/Resources.mdx
+++ b/libs/storybook-host/src/Resources.mdx
@@ -15,6 +15,7 @@ import { Meta } from '@storybook/addon-docs/blocks';
 ### Key Guides
 
 - **Getting Started** - Installation and basic usage
+- **Theming** - Shared theme ownership, palette, and branding overrides
 - **Best Practices** - Design principles and guidelines for signage
 - **Introduction** - Project overview and philosophy
 

--- a/libs/storybook-host/src/Theming.mdx
+++ b/libs/storybook-host/src/Theming.mdx
@@ -1,0 +1,207 @@
+import { ColorItem, ColorPalette, Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Theming" />
+
+# Theming
+
+This page explains the current theming model for `@wallrun/shadcnui-signage`, where the default values live, and how to adapt the library for a different brand without forking component internals.
+
+## The Current Theme Model
+
+The signage library uses two layers of styling ownership.
+
+### 1. Shared Token Layer
+
+The neutral base theme lives in `libs/common-tailwind`.
+
+- `libs/common-tailwind/src/shadcn-theme.css` defines the shared CSS variables such as `--background`, `--foreground`, `--card`, `--accent`, `--border`, and `--ring`.
+- `libs/common-tailwind/src/main.css` exposes those variables to Tailwind as semantic colors such as `bg-background`, `text-foreground`, `bg-card`, and `text-muted-foreground`.
+- `libs/common-tailwind/DESIGN.md` defines the contract: the shared theme should stay signage-safe, high-contrast, and brand-neutral.
+
+This is the layer to override when you want a different venue, tenant, or customer identity across an application.
+
+### 2. Signage Composition Layer
+
+The signage components add a second layer of visual control.
+
+- `SignageContainer` provides fixed gradient variants and ambient treatments for full-screen shells.
+- blocks such as `MenuBoard` and `FullscreenHero` expose class-name hooks for titles, subtitles, eyebrows, and content regions.
+- stories and apps can add venue-specific gradients, imagery, and emphasis at the composition layer.
+
+This is important because the current signage surface is not fully tokenized yet. The neutral shared tokens control the base surface, but some signage-specific treatments still live in component classes and variants.
+
+## Default Shared Palette
+
+These are the shared defaults defined in `libs/common-tailwind/src/shadcn-theme.css`.
+
+<ColorPalette>
+  <ColorItem
+    title="Base surfaces"
+    subtitle="Neutral screen-safe backgrounds and containers"
+    colors={{
+      Background: 'hsl(220 13% 12%)',
+      Card: 'hsl(220 13% 14%)',
+      Popover: 'hsl(220 13% 12%)',
+      Primary: 'hsl(220 13% 10%)',
+    }}
+  />
+  <ColorItem
+    title="Readable text"
+    subtitle="High-contrast foreground and muted supporting copy"
+    colors={{
+      Foreground: 'hsl(0 0% 90%)',
+      CardForeground: 'hsl(0 0% 90%)',
+      MutedForeground: 'hsl(210 5% 64%)',
+      PrimaryForeground: 'hsl(0 0% 90%)',
+    }}
+  />
+  <ColorItem
+    title="Structural accents"
+    subtitle="Accent, border, ring, and destructive states"
+    colors={{
+      Accent: 'hsl(215 8% 47%)',
+      Border: 'hsl(220 10% 25%)',
+      Ring: 'hsl(215 8% 47%)',
+      Destructive: 'hsl(0 62% 50%)',
+    }}
+  />
+  <ColorItem
+    title="Built-in signage shells"
+    subtitle="Representative `SignageContainer` gradient families"
+    colors={{
+      Emerald: 'linear-gradient(135deg, rgb(2 6 23), rgb(6 78 59 / 0.3), rgb(2 6 23))',
+      Teal: 'linear-gradient(135deg, rgb(2 6 23), rgb(4 47 46), rgb(2 6 23))',
+      Indigo: 'linear-gradient(135deg, rgb(30 27 75), rgb(88 28 135), rgb(131 24 67))',
+      Orange: 'linear-gradient(135deg, rgb(2 6 23), rgb(124 45 18 / 0.2), rgb(2 6 23))',
+    }}
+  />
+</ColorPalette>
+
+## What Should Be Customized Where
+
+Use the smallest layer that changes the right thing.
+
+### Override Shared Tokens When
+
+- the whole application needs a different neutral surface
+- foreground, accent, border, or ring colors should change consistently
+- you want apps and libraries to inherit the same base identity
+
+### Use Component-Level Styling When
+
+- a specific screen needs a venue-specific gradient or hero treatment
+- a board title, eyebrow, or badge needs brand emphasis
+- the shared neutral tokens should stay reusable, but one composition needs a stronger personality
+
+### Avoid Story-Level Ad Hoc Styling When
+
+- the same overrides appear in multiple stories or screens
+- a customer or venue identity needs to be repeated across an app
+- the change really belongs in a shared app shell or theme wrapper
+
+If a color decision should persist across screens, it belongs in the app theme. If it is specific to one screen composition, it belongs in the component usage layer.
+
+## Primary Customization Hooks
+
+These are the main places to work today.
+
+- `libs/common-tailwind/src/shadcn-theme.css`: shared neutral CSS variables
+- `libs/common-tailwind/src/main.css`: semantic Tailwind exposure of those variables
+- `libs/common-tailwind/DESIGN.md`: shared-theme rules and guardrails
+- `libs/shadcnui-signage/DESIGN.md`: signage-specific visual constraints
+- `SignageContainer.variant`: shell-level gradient presets for full-screen surfaces
+- component class hooks such as `titleClassName`, `subtitleClassName`, `eyebrowClassName`, `contentClassName`, and related props on signage blocks and primitives
+
+## Before And After: Brand Override Example
+
+The simplest safe customization flow is:
+
+1. override the shared neutral tokens in your app stylesheet
+2. keep the shared theme brandless
+3. add screen-specific gradients or typography emphasis through component props
+
+### App Theme Override
+
+```css
+.brand-acme {
+  --background: 210 40% 10%;
+  --foreground: 210 40% 96%;
+  --card: 210 34% 14%;
+  --card-foreground: 210 40% 96%;
+  --muted: 210 28% 18%;
+  --muted-foreground: 200 18% 72%;
+  --accent: 185 89% 44%;
+  --accent-foreground: 210 40% 96%;
+  --border: 210 30% 24%;
+  --ring: 185 89% 44%;
+}
+```
+
+### Screen Composition Using The Override
+
+```tsx
+import {
+  MenuBoard,
+  MenuItem,
+  MenuSection,
+  SignageContainer,
+} from '@wallrun/shadcnui-signage';
+
+export function BrandedCafeScreen() {
+  return (
+    <SignageContainer
+      variant="blue"
+      className="brand-acme bg-gradient-to-br from-slate-950 via-cyan-950 to-slate-950"
+    >
+      <MenuBoard
+        eyebrow="Acme cafe"
+        title="Today"
+        subtitle="Breakfast until 11:30"
+        eyebrowClassName="border-cyan-400/30 bg-cyan-400/10"
+        titleClassName="text-cyan-50"
+        subtitleClassName="text-cyan-100/75"
+      >
+        <MenuSection title="Breakfast" contentClassName="space-y-5">
+          <MenuItem name="Classic Breakfast" price="$12.99" />
+        </MenuSection>
+      </MenuBoard>
+    </SignageContainer>
+  );
+}
+```
+
+## Visual Comparison
+
+<div className="grid gap-6 md:grid-cols-2">
+  <div className="rounded-2xl border border-border bg-card p-6 text-card-foreground shadow-sm">
+    <div className="text-sm uppercase tracking-[0.3em] text-muted-foreground">Default shared shell</div>
+    <div className="mt-4 rounded-2xl bg-gradient-to-br from-slate-950 via-teal-950 to-slate-950 p-6 text-white">
+      <div className="text-sm uppercase tracking-[0.3em] text-teal-300">Daily selection</div>
+      <div className="mt-4 text-4xl font-bold tracking-tight">Cafe board</div>
+      <div className="mt-2 text-lg text-slate-300">Neutral shared palette with built-in signage variant.</div>
+    </div>
+  </div>
+
+  <div className="brand-acme rounded-2xl border border-border bg-card p-6 text-card-foreground shadow-sm">
+    <div className="text-sm uppercase tracking-[0.3em] text-muted-foreground">Branded override</div>
+    <div className="mt-4 rounded-2xl bg-gradient-to-br from-slate-950 via-cyan-950 to-slate-950 p-6 text-white">
+      <div className="text-sm uppercase tracking-[0.3em] text-cyan-300">Acme cafe</div>
+      <div className="mt-4 text-4xl font-bold tracking-tight text-cyan-50">Cafe board</div>
+      <div className="mt-2 text-lg text-cyan-100/75">Shared tokens changed at the app layer, then tuned in the screen composition.</div>
+    </div>
+  </div>
+</div>
+
+## Practical Rules
+
+- keep `common-tailwind` neutral and signage-safe
+- put brand identity in the consuming app, not the shared library
+- use semantic tokens for reusable surfaces before reaching for one-off classes
+- use component-level class hooks when the change belongs to one screen, not the whole app
+- treat Storybook examples as customization guidance, not the source of truth for theme ownership
+
+## Read This Next
+
+- return to `Getting Started` if you want the shortest path to a working screen
+- read `Best Practices` if you are deciding where behaviour belongs in a composition
+- use `Resources` for external documentation and project links

--- a/libs/storybook-host/src/Theming.mdx
+++ b/libs/storybook-host/src/Theming.mdx
@@ -109,7 +109,7 @@ These are the main places to work today.
 - `libs/common-tailwind/src/main.css`: semantic Tailwind exposure of those variables
 - `libs/common-tailwind/DESIGN.md`: shared-theme rules and guardrails
 - `libs/shadcnui-signage/DESIGN.md`: signage-specific visual constraints
-- `SignageContainer.variant`: shell-level gradient presets for full-screen surfaces
+- `SignageContainer` `variant` prop: shell-level gradient presets for full-screen surfaces
 - component class hooks such as `titleClassName`, `subtitleClassName`, `eyebrowClassName`, `contentClassName`, and related props on signage blocks and primitives
 
 ## Before And After: Brand Override Example


### PR DESCRIPTION
## Summary

- add a top-level `Theming` page to Storybook documenting token ownership, customization hooks, and brand override patterns for `@wallrun/shadcnui-signage`
- link the new theming docs into the existing top-level Storybook docs flow
- add a local `.storybook` TypeScript config to resolve the shared Storybook styling entry cleanly in editor diagnostics
- align the Storybook manager logo with the client demo by switching to the shared `wallrun-mark` branding asset

## Validation

- `NX_TUI=false pnpm nx run storybook-host:lint --outputStyle=static`
- opened `http://localhost:4400/?path=/docs/theming--documentation`
- confirmed Storybook manager header now serves `./wallrun-mark.svg`

## Notes

- this addresses follow-up issue #71
- the logo alignment is bundled with the docs slice because both changes affect the top-level Storybook surface