### PR TITLE
fix(registry): harden signage registry item metadata

### DIFF
--- a/apps/client/public/registry/registry.json
+++ b/apps/client/public/registry/registry.json
@@ -29,6 +29,14 @@
         {
           "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/primitives/ScreenFrame.tsx",
           "type": "registry:component"
+        },
+        {
+          "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/utils/resolution.ts",
+          "type": "registry:lib"
+        },
+        {
+          "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/types/signage.types.ts",
+          "type": "registry:lib"
         }
       ]
     },
@@ -187,6 +195,10 @@
         {
           "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/layouts/SplitScreen.tsx",
           "type": "registry:component"
+        },
+        {
+          "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/types/signage.types.ts",
+          "type": "registry:lib"
         }
       ]
     },
@@ -224,11 +236,19 @@
       "title": "Fullscreen Hero",
       "description": "Hero section for welcome screens and main messages. Light/dark variants with optional background images and CTA.",
       "registryDependencies": [],
-      "dependencies": ["lucide-react"],
+      "dependencies": [],
       "files": [
         {
           "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/blocks/FullscreenHero.tsx",
           "type": "registry:component"
+        },
+        {
+          "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/utils/clamp.ts",
+          "type": "registry:lib"
+        },
+        {
+          "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/types/signage.types.ts",
+          "type": "registry:lib"
         }
       ]
     },
@@ -236,13 +256,21 @@
       "name": "info-card-grid",
       "type": "registry:component",
       "title": "Info Card Grid",
-      "description": "Grid layout for displaying informational cards with icons, titles, and descriptions. Responsive column layout.",
+      "description": "Grid layout for displaying informational cards with titles, values, descriptions, and optional meta text. Responsive column layout.",
       "registryDependencies": [],
       "dependencies": [],
       "files": [
         {
           "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/blocks/InfoCardGrid.tsx",
           "type": "registry:component"
+        },
+        {
+          "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/utils/clamp.ts",
+          "type": "registry:lib"
+        },
+        {
+          "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/types/signage.types.ts",
+          "type": "registry:lib"
         }
       ]
     },
@@ -300,6 +328,10 @@
       "files": [
         {
           "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/behaviour/ContentRotator.tsx",
+          "type": "registry:component"
+        },
+        {
+          "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/behaviour/SignageTransition.tsx",
           "type": "registry:component"
         },
         {
@@ -420,7 +452,7 @@
       "title": "Stale Data Indicator",
       "description": "Shows visual indicator when data exceeds a freshness threshold. Useful for monitoring real-time data feeds.",
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": ["lucide-react"],
       "files": [
         {
           "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/behaviour/StaleDataIndicator.tsx",

--- a/docs/plans/2026-05-02-registry-transitive-audit.md
+++ b/docs/plans/2026-05-02-registry-transitive-audit.md
@@ -1,0 +1,26 @@
+# Registry Transitive Audit Plan
+
+## Goal
+Audit `apps/client/public/registry/registry.json` for missing transitive local files and missing non-workspace dependency declarations, then patch the registry metadata so published shadcn registry installs are coherent.
+
+## Context
+Issue #73 tracks follow-up hardening after the initial registry expansion work. Several registry entries may reference source files that import local utilities, local types, other signage components, or external packages without declaring them in the registry item metadata.
+
+## Approach
+1. Inspect each registry item and trace its direct imports.
+2. Identify missing local transitive files that should be included in `files`.
+3. Identify missing non-workspace package dependencies that should be included in `dependencies`.
+4. Patch `apps/client/public/registry/registry.json` with the minimum needed changes.
+5. Validate the resulting registry for obvious consistency.
+
+## Files Likely Touched
+- `apps/client/public/registry/registry.json`
+- `docs/plans/2026-05-02-registry-transitive-audit.md`
+
+## Validation
+- Re-read affected registry entries after patching.
+- Cross-check patched items against their current imports.
+- Run focused workspace checks if available for JSON or affected surfaces.
+
+## Expected Result
+Registry entries declare the local transitive files and external dependencies they actually need, reducing the chance that shadcn registry installs fail or arrive incomplete.


### PR DESCRIPTION
## Summary

Hardens `apps/client/public/registry/registry.json` by adding direct transitive files and correcting a small set of dependency and description mismatches discovered during the registry audit.

This addresses the immediate metadata correctness part of #73 without widening scope into the larger public dependency-model rewrite tracked separately.

## What Changed

- Added missing local transitive files for:
  - `screen-frame`
  - `split-screen`
  - `fullscreen-hero`
  - `info-card-grid`
  - `content-rotator`
- Corrected `stale-data-indicator` to declare `lucide-react`
- Removed an incorrect `lucide-react` dependency from `fullscreen-hero`
- Updated `info-card-grid` description to reflect its actual API more accurately
- Added the audit plan note in `docs/plans/2026-05-02-registry-transitive-audit.md`

## Why

Several registry items were missing direct local files required by their current imports. That made the published registry more brittle than it looked, even when the top-level item entry appeared valid.

This patch fixes the concrete misses that could be verified directly from source imports.

## Validation

- Parsed and re-checked `apps/client/public/registry/registry.json`
- Confirmed no editor diagnostics for the JSON file
- Ran focused mechanical assertions against the patched entries to verify:
  - expected transitive files are present
  - `stale-data-indicator` includes `lucide-react`
  - `fullscreen-hero` no longer declares `lucide-react`

## Scope Boundary

This PR does **not** solve the broader architectural issue that many registry-exported signage files still import `@wallrun/shadcnui`, which is a workspace-local package and not a public npm dependency.

That deeper follow-up is tracked separately in #78.

## Related

- Advances #73
- Related: #77
- Related: #78
