### PR TITLE
fix(registry): remove workspace-only signage imports

### DIFF
--- a/apps/client/public/registry/registry.json
+++ b/apps/client/public/registry/registry.json
@@ -10,7 +10,7 @@
       "title": "Metric Card",
       "description": "Display KPIs and metrics with values, change indicators, and icons. Optimized for distance readability on signage displays.",
       "registryDependencies": [],
-      "dependencies": ["lucide-react"],
+      "dependencies": ["clsx", "lucide-react", "tailwind-merge"],
       "files": [
         {
           "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/primitives/MetricCard.tsx",
@@ -50,7 +50,7 @@
       "title": "Event Card",
       "description": "Display event information with time, title, speaker, location, and track. Commonly used in event schedules and conference displays.",
       "registryDependencies": [],
-      "dependencies": ["lucide-react"],
+      "dependencies": ["clsx", "lucide-react", "tailwind-merge"],
       "files": [
         {
           "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/primitives/EventCard.tsx",
@@ -68,7 +68,7 @@
       "title": "Announcement Card",
       "description": "Display announcement information with title, description, date, icon, and category. Glass morphism effects for modern look.",
       "registryDependencies": [],
-      "dependencies": ["lucide-react"],
+      "dependencies": ["clsx", "lucide-react", "tailwind-merge"],
       "files": [
         {
           "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/primitives/AnnouncementCard.tsx",
@@ -86,7 +86,7 @@
       "title": "Directory Card",
       "description": "Wayfinding card with department, floor, room, and contact metadata for directory and lobby signage.",
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": ["clsx", "tailwind-merge"],
       "files": [
         {
           "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/primitives/DirectoryCard.tsx",
@@ -108,7 +108,7 @@
       "title": "Floor Badge",
       "description": "Compact floor badge for wayfinding, room directories, and map overlays.",
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": ["clsx", "tailwind-merge"],
       "files": [
         {
           "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/primitives/FloorBadge.tsx",
@@ -126,7 +126,7 @@
       "title": "Location Indicator",
       "description": "Current-location indicator with map pin iconography for wayfinding and directory signage.",
       "registryDependencies": [],
-      "dependencies": ["lucide-react"],
+      "dependencies": ["clsx", "lucide-react", "tailwind-merge"],
       "files": [
         {
           "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/primitives/LocationIndicator.tsx",
@@ -144,7 +144,7 @@
       "title": "Menu Item",
       "description": "Menu row with item name, price, optional description, and signage-sized typography.",
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": ["clsx", "tailwind-merge"],
       "files": [
         {
           "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/primitives/MenuItem.tsx",
@@ -162,7 +162,7 @@
       "title": "Menu Section",
       "description": "Section wrapper for grouped menu categories with headline and accent divider.",
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": ["clsx", "tailwind-merge"],
       "files": [
         {
           "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/primitives/MenuSection.tsx",
@@ -180,7 +180,7 @@
       "title": "Signage Panel",
       "description": "Bordered content panel for grouped supporting information on lobby and operational screens.",
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": ["clsx", "tailwind-merge"],
       "files": [
         {
           "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/primitives/SignagePanel.tsx",
@@ -198,7 +198,7 @@
       "title": "Meeting Row",
       "description": "Agenda-style row for schedules, room bookings, and office lobby meeting lists.",
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": ["clsx", "tailwind-merge"],
       "files": [
         {
           "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/primitives/MeetingRow.tsx",
@@ -216,7 +216,7 @@
       "title": "Info List",
       "description": "Large-format list for lobby notices, visitor instructions, and operational status notes.",
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": ["clsx", "tailwind-merge"],
       "files": [
         {
           "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/primitives/InfoList.tsx",
@@ -234,7 +234,7 @@
       "title": "Split Screen",
       "description": "Two-panel layout with configurable ratio and direction. Perfect for showing multiple content streams side-by-side.",
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": ["clsx", "tailwind-merge"],
       "files": [
         {
           "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/layouts/SplitScreen.tsx",
@@ -252,7 +252,7 @@
       "title": "Signage Container",
       "description": "Full-screen container with gradient backgrounds, ambient orb effects, and optional grid overlay. 8 color variants available.",
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": ["clsx", "tailwind-merge"],
       "files": [
         {
           "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/layouts/SignageContainer.tsx",
@@ -270,7 +270,7 @@
       "title": "Signage Header",
       "description": "Standard signage header with optional tag badge, title, and subtitle. Multiple color variants and alignment options.",
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": ["clsx", "tailwind-merge"],
       "files": [
         {
           "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/layouts/SignageHeader.tsx",
@@ -288,7 +288,7 @@
       "title": "Fullscreen Hero",
       "description": "Hero section for welcome screens and main messages. Light/dark variants with optional background images and CTA.",
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": ["clsx", "tailwind-merge"],
       "files": [
         {
           "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/blocks/FullscreenHero.tsx",
@@ -314,7 +314,7 @@
       "title": "Info Card Grid",
       "description": "Grid layout for displaying informational cards with titles, values, descriptions, and optional meta text. Responsive column layout.",
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": ["clsx", "tailwind-merge"],
       "files": [
         {
           "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/blocks/InfoCardGrid.tsx",
@@ -344,7 +344,7 @@
       "title": "Menu Board",
       "description": "Full-screen menu board shell with header, subtitle, and content region for restaurant and daypart signage.",
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": ["clsx", "tailwind-merge"],
       "files": [
         {
           "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/blocks/MenuBoard.tsx",
@@ -366,7 +366,7 @@
       "title": "Auto Paging List",
       "description": "Renders long lists as pages with automatic advancement. Perfect for scrolling-free displays with configurable dwell time per page.",
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": ["clsx", "tailwind-merge"],
       "files": [
         {
           "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/behaviour/AutoPagingList.tsx",
@@ -396,7 +396,7 @@
       "title": "Content Rotator",
       "description": "Cycles through children at fixed intervals with transitions. Supports pause/resume and dynamic content updates.",
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": ["clsx", "tailwind-merge"],
       "files": [
         {
           "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/behaviour/ContentRotator.tsx",
@@ -430,7 +430,7 @@
       "title": "Schedule Gate",
       "description": "Conditionally renders content based on weekday and time windows. Supports timezone-aware scheduling for daypart menus and time-based content.",
       "registryDependencies": [],
-      "dependencies": ["date-fns-tz"],
+      "dependencies": ["clsx", "date-fns-tz", "tailwind-merge"],
       "files": [
         {
           "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/behaviour/ScheduleGate.tsx",
@@ -456,7 +456,7 @@
       "title": "Signage Transition",
       "description": "Wraps a single child with signage-appropriate transitions (crossfade, slide). Respects prefers-reduced-motion.",
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": ["clsx", "tailwind-merge"],
       "files": [
         {
           "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/behaviour/SignageTransition.tsx",
@@ -478,7 +478,7 @@
       "title": "Clock",
       "description": "Displays current time with configurable format and timezone. Updates at minute boundaries for efficiency.",
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": ["clsx", "tailwind-merge"],
       "files": [
         {
           "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/behaviour/Clock.tsx",
@@ -504,7 +504,7 @@
       "title": "Countdown",
       "description": "Counts down to a target date/time with configurable format. When the target is reached, the timer stops at zero.",
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": ["clsx", "tailwind-merge"],
       "files": [
         {
           "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/behaviour/Countdown.tsx",
@@ -530,7 +530,7 @@
       "title": "Offline Fallback",
       "description": "Shows fallback UI when content is offline or unhealthy. Manual recovery control for graceful degradation.",
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": ["clsx", "tailwind-merge"],
       "files": [
         {
           "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/behaviour/OfflineFallback.tsx",
@@ -548,7 +548,7 @@
       "title": "Stale Data Indicator",
       "description": "Shows visual indicator when data exceeds a freshness threshold. Useful for monitoring real-time data feeds.",
       "registryDependencies": [],
-      "dependencies": ["lucide-react"],
+      "dependencies": ["clsx", "lucide-react", "tailwind-merge"],
       "files": [
         {
           "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/behaviour/StaleDataIndicator.tsx",

--- a/apps/client/public/registry/registry.json
+++ b/apps/client/public/registry/registry.json
@@ -15,6 +15,10 @@
         {
           "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/primitives/MetricCard.tsx",
           "type": "registry:component"
+        },
+        {
+          "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/utils/cn.ts",
+          "type": "registry:lib"
         }
       ]
     },
@@ -51,6 +55,10 @@
         {
           "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/primitives/EventCard.tsx",
           "type": "registry:component"
+        },
+        {
+          "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/utils/cn.ts",
+          "type": "registry:lib"
         }
       ]
     },
@@ -65,6 +73,10 @@
         {
           "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/primitives/AnnouncementCard.tsx",
           "type": "registry:component"
+        },
+        {
+          "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/utils/cn.ts",
+          "type": "registry:lib"
         }
       ]
     },
@@ -83,6 +95,10 @@
         {
           "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/primitives/FloorBadge.tsx",
           "type": "registry:component"
+        },
+        {
+          "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/utils/cn.ts",
+          "type": "registry:lib"
         }
       ]
     },
@@ -97,6 +113,10 @@
         {
           "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/primitives/FloorBadge.tsx",
           "type": "registry:component"
+        },
+        {
+          "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/utils/cn.ts",
+          "type": "registry:lib"
         }
       ]
     },
@@ -111,6 +131,10 @@
         {
           "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/primitives/LocationIndicator.tsx",
           "type": "registry:component"
+        },
+        {
+          "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/utils/cn.ts",
+          "type": "registry:lib"
         }
       ]
     },
@@ -125,6 +149,10 @@
         {
           "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/primitives/MenuItem.tsx",
           "type": "registry:component"
+        },
+        {
+          "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/utils/cn.ts",
+          "type": "registry:lib"
         }
       ]
     },
@@ -139,6 +167,10 @@
         {
           "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/primitives/MenuSection.tsx",
           "type": "registry:component"
+        },
+        {
+          "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/utils/cn.ts",
+          "type": "registry:lib"
         }
       ]
     },
@@ -153,6 +185,10 @@
         {
           "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/primitives/SignagePanel.tsx",
           "type": "registry:component"
+        },
+        {
+          "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/utils/cn.ts",
+          "type": "registry:lib"
         }
       ]
     },
@@ -167,6 +203,10 @@
         {
           "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/primitives/MeetingRow.tsx",
           "type": "registry:component"
+        },
+        {
+          "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/utils/cn.ts",
+          "type": "registry:lib"
         }
       ]
     },
@@ -181,6 +221,10 @@
         {
           "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/primitives/InfoList.tsx",
           "type": "registry:component"
+        },
+        {
+          "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/utils/cn.ts",
+          "type": "registry:lib"
         }
       ]
     },
@@ -213,6 +257,10 @@
         {
           "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/layouts/SignageContainer.tsx",
           "type": "registry:component"
+        },
+        {
+          "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/utils/cn.ts",
+          "type": "registry:lib"
         }
       ]
     },
@@ -227,6 +275,10 @@
         {
           "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/layouts/SignageHeader.tsx",
           "type": "registry:component"
+        },
+        {
+          "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/utils/cn.ts",
+          "type": "registry:lib"
         }
       ]
     },
@@ -244,6 +296,10 @@
         },
         {
           "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/utils/clamp.ts",
+          "type": "registry:lib"
+        },
+        {
+          "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/utils/cn.ts",
           "type": "registry:lib"
         },
         {
@@ -269,6 +325,14 @@
           "type": "registry:lib"
         },
         {
+          "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/utils/cn.ts",
+          "type": "registry:lib"
+        },
+        {
+          "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/utils/card.tsx",
+          "type": "registry:lib"
+        },
+        {
           "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/types/signage.types.ts",
           "type": "registry:lib"
         }
@@ -289,6 +353,10 @@
         {
           "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/layouts/SignageContainer.tsx",
           "type": "registry:component"
+        },
+        {
+          "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/utils/cn.ts",
+          "type": "registry:lib"
         }
       ]
     },
@@ -314,6 +382,10 @@
         },
         {
           "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/types/time.types.ts",
+          "type": "registry:lib"
+        },
+        {
+          "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/utils/cn.ts",
           "type": "registry:lib"
         }
       ]
@@ -345,6 +417,10 @@
         {
           "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/types/time.types.ts",
           "type": "registry:lib"
+        },
+        {
+          "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/utils/cn.ts",
+          "type": "registry:lib"
         }
       ]
     },
@@ -367,6 +443,10 @@
         {
           "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/types/time.types.ts",
           "type": "registry:lib"
+        },
+        {
+          "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/utils/cn.ts",
+          "type": "registry:lib"
         }
       ]
     },
@@ -384,6 +464,10 @@
         },
         {
           "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/hooks/usePrefersReducedMotion.ts",
+          "type": "registry:lib"
+        },
+        {
+          "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/utils/cn.ts",
           "type": "registry:lib"
         }
       ]
@@ -407,6 +491,10 @@
         {
           "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/types/time.types.ts",
           "type": "registry:lib"
+        },
+        {
+          "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/utils/cn.ts",
+          "type": "registry:lib"
         }
       ]
     },
@@ -429,6 +517,10 @@
         {
           "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/types/time.types.ts",
           "type": "registry:lib"
+        },
+        {
+          "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/utils/cn.ts",
+          "type": "registry:lib"
         }
       ]
     },
@@ -443,6 +535,10 @@
         {
           "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/behaviour/OfflineFallback.tsx",
           "type": "registry:component"
+        },
+        {
+          "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/utils/cn.ts",
+          "type": "registry:lib"
         }
       ]
     },
@@ -464,6 +560,10 @@
         },
         {
           "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/types/time.types.ts",
+          "type": "registry:lib"
+        },
+        {
+          "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/utils/cn.ts",
           "type": "registry:lib"
         }
       ]

--- a/docs/plans/2026-05-02-registry-safe-signage-imports.md
+++ b/docs/plans/2026-05-02-registry-safe-signage-imports.md
@@ -1,0 +1,29 @@
+# Registry-Safe Signage Imports Plan
+
+## Goal
+
+Start issue #78 by removing the `@wallrun/shadcnui` alias from a low-risk set of registry-facing signage primitives and replacing it with local registry-safe imports.
+
+## Context
+
+The merged registry audit fixed missing transitive files, but many public registry items still depend on the workspace-local `@wallrun/shadcnui` package. That keeps installs tied to monorepo assumptions.
+
+## First Slice
+
+Use a local `cn` utility in `libs/shadcnui-signage/src/lib/utils/` and migrate the lowest-risk primitives that only need `cn` plus local or npm imports:
+
+- `SignagePanel`
+- `InfoList`
+- `MeetingRow`
+- `FloorBadge`
+- `LocationIndicator`
+- `DirectoryCard`
+
+## Validation
+
+- Run the existing primitive tests covering these components.
+- Update matching registry entries to include the new local utility file once the import migration is proven.
+
+## Expected Result
+
+A small but real subset of public signage components no longer depends on `@wallrun/shadcnui`, establishing the migration pattern for the rest of issue #78.

--- a/libs/shadcnui-signage/src/lib/behaviour/AutoPagingList.tsx
+++ b/libs/shadcnui-signage/src/lib/behaviour/AutoPagingList.tsx
@@ -1,5 +1,5 @@
 import { type ReactNode, useEffect, useMemo, useRef, useState } from 'react';
-import { cn } from '@wallrun/shadcnui';
+import { cn } from '../utils/cn';
 import type { NowProvider } from '../types/time.types';
 import { useTicker } from '../hooks/useTicker';
 

--- a/libs/shadcnui-signage/src/lib/behaviour/Clock.tsx
+++ b/libs/shadcnui-signage/src/lib/behaviour/Clock.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { cn } from '@wallrun/shadcnui';
+import { cn } from '../utils/cn';
 import type { NowProvider } from '../types/time.types';
 import { useTicker } from '../hooks/useTicker';
 

--- a/libs/shadcnui-signage/src/lib/behaviour/ContentRotator.tsx
+++ b/libs/shadcnui-signage/src/lib/behaviour/ContentRotator.tsx
@@ -1,5 +1,5 @@
 import { type ReactNode, useEffect, useMemo, useRef, useState } from 'react';
-import { cn } from '@wallrun/shadcnui';
+import { cn } from '../utils/cn';
 import type { NowProvider } from '../types/time.types';
 import { useTicker } from '../hooks/useTicker';
 import { SignageTransition } from './SignageTransition';

--- a/libs/shadcnui-signage/src/lib/behaviour/Countdown.tsx
+++ b/libs/shadcnui-signage/src/lib/behaviour/Countdown.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef } from 'react';
-import { cn } from '@wallrun/shadcnui';
+import { cn } from '../utils/cn';
 import type { NowProvider } from '../types/time.types';
 import { useTicker } from '../hooks/useTicker';
 

--- a/libs/shadcnui-signage/src/lib/behaviour/OfflineFallback.tsx
+++ b/libs/shadcnui-signage/src/lib/behaviour/OfflineFallback.tsx
@@ -1,5 +1,5 @@
 import { type ReactNode, useEffect, useState } from 'react';
-import { cn } from '@wallrun/shadcnui';
+import { cn } from '../utils/cn';
 
 export interface OfflineFallbackProps {
   isOnline?: boolean;

--- a/libs/shadcnui-signage/src/lib/behaviour/ScheduleGate.tsx
+++ b/libs/shadcnui-signage/src/lib/behaviour/ScheduleGate.tsx
@@ -1,5 +1,5 @@
 import { type ReactNode } from 'react';
-import { cn } from '@wallrun/shadcnui';
+import { cn } from '../utils/cn';
 import { toZonedTime } from 'date-fns-tz';
 import type { NowProvider } from '../types/time.types';
 import { useTicker } from '../hooks/useTicker';

--- a/libs/shadcnui-signage/src/lib/behaviour/SignageTransition.tsx
+++ b/libs/shadcnui-signage/src/lib/behaviour/SignageTransition.tsx
@@ -5,7 +5,7 @@ import {
   useRef,
   useState,
 } from 'react';
-import { cn } from '@wallrun/shadcnui';
+import { cn } from '../utils/cn';
 import { usePrefersReducedMotion } from '../hooks/usePrefersReducedMotion';
 
 export interface SignageTransitionProps {

--- a/libs/shadcnui-signage/src/lib/behaviour/StaleDataIndicator.tsx
+++ b/libs/shadcnui-signage/src/lib/behaviour/StaleDataIndicator.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { AlertTriangle, CheckCircle2, Clock3 } from 'lucide-react';
-import { cn } from '@wallrun/shadcnui';
+import { cn } from '../utils/cn';
 import type { NowProvider } from '../types/time.types';
 import { useTicker } from '../hooks/useTicker';
 

--- a/libs/shadcnui-signage/src/lib/blocks/FullscreenHero.tsx
+++ b/libs/shadcnui-signage/src/lib/blocks/FullscreenHero.tsx
@@ -1,5 +1,5 @@
 import { type ReactNode } from 'react';
-import { cn } from '@wallrun/shadcnui';
+import { cn } from '../utils/cn';
 import { getClampClass } from '../utils/clamp';
 import type { Variant } from '../types/signage.types';
 

--- a/libs/shadcnui-signage/src/lib/blocks/InfoCardGrid.tsx
+++ b/libs/shadcnui-signage/src/lib/blocks/InfoCardGrid.tsx
@@ -1,11 +1,11 @@
+import { cn } from '../utils/cn';
 import {
-  cn,
   Card,
   CardContent,
   CardDescription,
   CardHeader,
   CardTitle,
-} from '@wallrun/shadcnui';
+} from '../utils/card';
 import { getClampClass } from '../utils/clamp';
 import type {
   InfoCardItem,

--- a/libs/shadcnui-signage/src/lib/blocks/MenuBoard.tsx
+++ b/libs/shadcnui-signage/src/lib/blocks/MenuBoard.tsx
@@ -1,5 +1,5 @@
 import { FC, ReactNode } from 'react';
-import { cn } from '@wallrun/shadcnui';
+import { cn } from '../utils/cn';
 import { SignageContainer } from '../layouts/SignageContainer';
 import type { GradientVariant } from '../layouts/SignageContainer';
 

--- a/libs/shadcnui-signage/src/lib/layouts/SignageContainer.tsx
+++ b/libs/shadcnui-signage/src/lib/layouts/SignageContainer.tsx
@@ -1,5 +1,5 @@
 import { FC, ReactNode } from 'react';
-import { cn } from '@wallrun/shadcnui';
+import { cn } from '../utils/cn';
 
 export type GradientVariant =
   | 'emerald'

--- a/libs/shadcnui-signage/src/lib/layouts/SignageHeader.tsx
+++ b/libs/shadcnui-signage/src/lib/layouts/SignageHeader.tsx
@@ -1,5 +1,5 @@
 import { FC, ReactNode } from 'react';
-import { cn } from '@wallrun/shadcnui';
+import { cn } from '../utils/cn';
 
 export interface SignageHeaderProps {
   /**
@@ -96,7 +96,9 @@ export const SignageHeader: FC<SignageHeaderProps> = ({
   const alignmentClasses = alignment === 'center' ? 'text-center' : 'text-left';
 
   return (
-    <header className={cn('mb-10 sm:mb-12 lg:mb-16', alignmentClasses, className)}>
+    <header
+      className={cn('mb-10 sm:mb-12 lg:mb-16', alignmentClasses, className)}
+    >
       {tag && (
         <div
           className={cn(

--- a/libs/shadcnui-signage/src/lib/primitives/AnnouncementCard.tsx
+++ b/libs/shadcnui-signage/src/lib/primitives/AnnouncementCard.tsx
@@ -1,6 +1,6 @@
 import { FC, ReactNode } from 'react';
 import { LucideIcon } from 'lucide-react';
-import { cn } from '@wallrun/shadcnui';
+import { cn } from '../utils/cn';
 
 export interface AnnouncementCardProps {
   /**

--- a/libs/shadcnui-signage/src/lib/primitives/DirectoryCard.tsx
+++ b/libs/shadcnui-signage/src/lib/primitives/DirectoryCard.tsx
@@ -1,5 +1,5 @@
 import { FC } from 'react';
-import { cn } from '@wallrun/shadcnui';
+import { cn } from '../utils/cn';
 import { FloorBadge } from './FloorBadge';
 
 export interface DirectoryCardProps {

--- a/libs/shadcnui-signage/src/lib/primitives/EventCard.tsx
+++ b/libs/shadcnui-signage/src/lib/primitives/EventCard.tsx
@@ -1,6 +1,6 @@
 import { FC } from 'react';
 import { Clock, MapPin } from 'lucide-react';
-import { cn } from '@wallrun/shadcnui';
+import { cn } from '../utils/cn';
 
 export interface EventCardProps {
   /**

--- a/libs/shadcnui-signage/src/lib/primitives/FloorBadge.tsx
+++ b/libs/shadcnui-signage/src/lib/primitives/FloorBadge.tsx
@@ -1,5 +1,5 @@
 import { FC } from 'react';
-import { cn } from '@wallrun/shadcnui';
+import { cn } from '../utils/cn';
 
 export interface FloorBadgeProps {
   /**

--- a/libs/shadcnui-signage/src/lib/primitives/InfoList.tsx
+++ b/libs/shadcnui-signage/src/lib/primitives/InfoList.tsx
@@ -1,5 +1,5 @@
 import { FC } from 'react';
-import { cn } from '@wallrun/shadcnui';
+import { cn } from '../utils/cn';
 
 export interface InfoListProps {
   /**

--- a/libs/shadcnui-signage/src/lib/primitives/LocationIndicator.tsx
+++ b/libs/shadcnui-signage/src/lib/primitives/LocationIndicator.tsx
@@ -1,6 +1,6 @@
 import { FC } from 'react';
 import { MapPin } from 'lucide-react';
-import { cn } from '@wallrun/shadcnui';
+import { cn } from '../utils/cn';
 
 export interface LocationIndicatorProps {
   /**

--- a/libs/shadcnui-signage/src/lib/primitives/MeetingRow.tsx
+++ b/libs/shadcnui-signage/src/lib/primitives/MeetingRow.tsx
@@ -1,5 +1,5 @@
 import { FC } from 'react';
-import { cn } from '@wallrun/shadcnui';
+import { cn } from '../utils/cn';
 
 export interface MeetingRowProps {
   /**

--- a/libs/shadcnui-signage/src/lib/primitives/MenuItem.tsx
+++ b/libs/shadcnui-signage/src/lib/primitives/MenuItem.tsx
@@ -1,5 +1,5 @@
 import { FC } from 'react';
-import { cn } from '@wallrun/shadcnui';
+import { cn } from '../utils/cn';
 
 export interface MenuItemProps {
   /**

--- a/libs/shadcnui-signage/src/lib/primitives/MenuSection.tsx
+++ b/libs/shadcnui-signage/src/lib/primitives/MenuSection.tsx
@@ -1,5 +1,5 @@
 import { FC, ReactNode } from 'react';
-import { cn } from '@wallrun/shadcnui';
+import { cn } from '../utils/cn';
 
 export interface MenuSectionProps {
   /**

--- a/libs/shadcnui-signage/src/lib/primitives/MetricCard.tsx
+++ b/libs/shadcnui-signage/src/lib/primitives/MetricCard.tsx
@@ -1,6 +1,6 @@
 import { FC, ReactNode } from 'react';
 import { ArrowUp, ArrowDown } from 'lucide-react';
-import { cn } from '@wallrun/shadcnui';
+import { cn } from '../utils/cn';
 
 export interface MetricCardProps {
   /**

--- a/libs/shadcnui-signage/src/lib/primitives/SignagePanel.tsx
+++ b/libs/shadcnui-signage/src/lib/primitives/SignagePanel.tsx
@@ -1,5 +1,5 @@
 import { FC, ReactNode } from 'react';
-import { cn } from '@wallrun/shadcnui';
+import { cn } from '../utils/cn';
 
 export interface SignagePanelProps {
   /**

--- a/libs/shadcnui-signage/src/lib/utils/card.tsx
+++ b/libs/shadcnui-signage/src/lib/utils/card.tsx
@@ -1,0 +1,63 @@
+import * as React from 'react';
+import { cn } from './cn';
+
+const Card = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      'rounded-(--radius) border bg-card text-card-foreground shadow-sm',
+      className,
+    )}
+    {...props}
+  />
+));
+Card.displayName = 'Card';
+
+const CardHeader = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn('flex flex-col space-y-1.5 p-6', className)}
+    {...props}
+  />
+));
+CardHeader.displayName = 'CardHeader';
+
+const CardTitle = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn('font-semibold leading-none tracking-tight', className)}
+    {...props}
+  />
+));
+CardTitle.displayName = 'CardTitle';
+
+const CardDescription = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn('text-sm text-muted-foreground', className)}
+    {...props}
+  />
+));
+CardDescription.displayName = 'CardDescription';
+
+const CardContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn('p-6 pt-0', className)} {...props} />
+));
+CardContent.displayName = 'CardContent';
+
+export { Card, CardContent, CardDescription, CardHeader, CardTitle };

--- a/libs/shadcnui-signage/src/lib/utils/cn.ts
+++ b/libs/shadcnui-signage/src/lib/utils/cn.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}


### PR DESCRIPTION
## Summary

This completes the registry-safe import migration for `shadcnui-signage` components that were still tied to the workspace-only `@wallrun/shadcnui` package.

### What changed

- added a local `cn` helper in `libs/shadcnui-signage/src/lib/utils/cn.ts`
- switched signage primitives, layouts, blocks, and behaviour components to import `cn` locally
- added a local card primitive subset in `libs/shadcnui-signage/src/lib/utils/card.tsx`
- updated `InfoCardGrid` to use the local card primitive instead of `@wallrun/shadcnui`
- updated `apps/client/public/registry/registry.json` so migrated registry items include the new helper files
- added a short implementation plan in `docs/plans/2026-05-02-registry-safe-signage-imports.md`

### Why

The public registry is intended to be installable outside the monorepo, but these components still depended on `@wallrun/shadcnui`, which is a workspace-local package. This change removes that assumption and keeps the registry metadata aligned with the actual transitive files external consumers need.

## Validation

### Targeted tests

- `libs/shadcnui-signage/src/lib/primitives/SignagePanel.spec.tsx`
- `libs/shadcnui-signage/src/lib/primitives/DirectoryCard.spec.tsx`
- `libs/shadcnui-signage/src/lib/blocks/MenuBoard.spec.tsx`
- `libs/shadcnui-signage/src/lib/blocks/FullscreenHero.spec.tsx`
- `libs/shadcnui-signage/src/lib/blocks/InfoCardGrid.spec.tsx`
- `libs/shadcnui-signage/src/lib/behaviour/AutoPagingList.test.tsx`
- `libs/shadcnui-signage/src/lib/behaviour/ContentRotator.test.tsx`
- `libs/shadcnui-signage/src/lib/behaviour/ScheduleGate.test.tsx`
- `libs/shadcnui-signage/src/lib/behaviour/SignageTransition.test.tsx`
- `libs/shadcnui-signage/src/lib/behaviour/Clock.test.tsx`
- `libs/shadcnui-signage/src/lib/behaviour/Countdown.test.tsx`
- `libs/shadcnui-signage/src/lib/behaviour/OfflineFallback.test.tsx`
- `libs/shadcnui-signage/src/lib/behaviour/StaleDataIndicator.test.tsx`

### Additional checks

- verified there are no remaining code imports from `@wallrun/shadcnui` under `libs/shadcnui-signage/src/lib`
- verified migrated registry items include the new helper files
- confirmed Storybook docs still render at:
  - `http://localhost:4400/?path=/docs/introduction--documentation`

### Repo-wide verification

- `pnpm verify` was attempted
- the only captured failure was formatting, which was corrected
- Nx switched the terminal into an alternate buffer in this environment, so I do not have a clean final plain-text `pnpm verify` transcript to paste here

Closes #78
