### PR TITLE
docs(storybook): add registry install guidance

### DIFF
--- a/docs/plans/2026-05-02-storybook-registry-install-docs.md
+++ b/docs/plans/2026-05-02-storybook-registry-install-docs.md
@@ -1,0 +1,34 @@
+# Storybook Registry Install Docs Plan
+
+## Goal
+
+Close issue #76 by documenting the published shadcn registry installation workflow in Storybook.
+
+## Context
+
+The client docs already explain how to install WallRun signage components from the published registry, but the Storybook docs still describe composition and workspace usage without telling consumers how to add components to an existing project.
+
+## Scope
+
+Update the Storybook documentation surfaces that frame usage and next steps:
+
+- `libs/storybook-host/src/GettingStarted.mdx`
+- `libs/storybook-host/src/Introduction.mdx`
+- `libs/storybook-host/src/Resources.mdx`
+
+## Content To Add
+
+- the published registry URL
+- a single-component install example
+- a multi-component install example
+- explicit explanation that components are copied into the consumer codebase
+- a pointer to broader docs for users who want full workspace setup
+
+## Validation
+
+- verify the docs render at `http://localhost:4400/?path=/docs/introduction--documentation`
+- verify the updated Storybook docs pages contain the registry install workflow and next-step links
+
+## Expected Result
+
+Storybook matches the client docs for registry installation guidance and no longer leaves external consumers guessing how to install signage components.

--- a/libs/storybook-host/src/GettingStarted.mdx
+++ b/libs/storybook-host/src/GettingStarted.mdx
@@ -27,6 +27,8 @@ pnpm serve:client
 
 If you already have a React app and only want the signage components, use the published shadcn registry instead of cloning the whole monorepo.
 
+These commands assume your app already has Tailwind and the shadcn CLI configured. If it does not, complete the [shadcn installation guide](https://ui.shadcn.com/docs/installation) before you add WallRun components.
+
 ```bash
 # Install one component
 npx shadcn@latest add https://cambridgemonorail.github.io/WallRun/registry/registry.json auto-paging-list
@@ -59,7 +61,7 @@ That distinction matters:
 
 That order keeps the screen stable and makes operational logic easier to reason about.
 
-If you already know the screen shape but need to make it fit a venue or customer brand, read `Theming` before you start adding ad hoc class overrides to stories or pages.
+If you already know the screen shape but need to make it fit a venue or customer brand, read [Theming](?path=/docs/theming--documentation) before you start adding ad hoc class overrides to stories or pages.
 
 ## Minimal Realistic Example
 
@@ -149,4 +151,4 @@ If a story reads like a small component test, treat it as API reference, not des
 
 ## Next Steps
 
-Read `Theming` next if you need to adapt the shared palette or screen chrome for a brand. Read `Best Practices` next if you want guidance on how to structure the screen itself. Read `Resources` if you want the GitHub repository, demo website, or broader project documentation.
+Read [Theming](?path=/docs/theming--documentation) next if you need to adapt the shared palette or screen chrome for a brand. Read [Best Practices](?path=/docs/best-practices--documentation) next if you want guidance on how to structure the screen itself. Read [Resources](?path=/docs/resources--documentation) if you want the GitHub repository, demo website, or broader project documentation.

--- a/libs/storybook-host/src/GettingStarted.mdx
+++ b/libs/storybook-host/src/GettingStarted.mdx
@@ -23,6 +23,22 @@ If you want the demo website as well:
 pnpm serve:client
 ```
 
+## Install Components Into An Existing App
+
+If you already have a React app and only want the signage components, use the published shadcn registry instead of cloning the whole monorepo.
+
+```bash
+# Install one component
+npx shadcn@latest add https://cambridgemonorail.github.io/WallRun/registry/registry.json auto-paging-list
+
+# Install several at once
+npx shadcn@latest add https://cambridgemonorail.github.io/WallRun/registry/registry.json metric-card event-card schedule-gate
+```
+
+This uses the shadcn CLI to copy the selected components into your codebase along with the files and npm dependencies they need. Once installed, you own that code and can adapt it to your project.
+
+Choose this route when you want WallRun signage primitives inside an existing application. Clone the full repository only if you also want the demo site, player scaffolding, deployment scripts, or the rest of the workspace tooling.
+
 ## Start With The Right Surface
 
 Use `SignageContainer` in real application screens.
@@ -133,4 +149,4 @@ If a story reads like a small component test, treat it as API reference, not des
 
 ## Next Steps
 
-Read `Theming` next if you need to adapt the shared palette or screen chrome for a brand. Read `Best Practices` next if you want guidance on how to structure the screen itself.
+Read `Theming` next if you need to adapt the shared palette or screen chrome for a brand. Read `Best Practices` next if you want guidance on how to structure the screen itself. Read `Resources` if you want the GitHub repository, demo website, or broader project documentation.

--- a/libs/storybook-host/src/GettingStarted.mdx
+++ b/libs/storybook-host/src/GettingStarted.mdx
@@ -27,7 +27,9 @@ pnpm serve:client
 
 If you already have a React app and only want the signage components, use the published shadcn registry instead of cloning the whole monorepo.
 
-These commands assume your app already has Tailwind and the shadcn CLI configured. If it does not, complete the [shadcn installation guide](https://ui.shadcn.com/docs/installation) before you add WallRun components.
+Before running these commands, make sure you are inside a React app that is already set up for Tailwind CSS and `shadcn/ui`. If your app is not ready yet, complete the [shadcn installation guide](https://ui.shadcn.com/docs/installation) first.
+
+Run the following commands from the root of that prepared app:
 
 ```bash
 # Install one component

--- a/libs/storybook-host/src/Introduction.mdx
+++ b/libs/storybook-host/src/Introduction.mdx
@@ -15,11 +15,11 @@ You can use this Storybook in two ways:
 
 ## Install From The Published Registry
 
-If you do not need the full monorepo, install individual signage components from the published registry.
+If you do not need the full monorepo, you can install individual signage components from the published registry.
 
-Before you run these commands, start from an app that already has Tailwind and the shadcn CLI set up. If you have not done that yet, follow the [shadcn installation guide](https://ui.shadcn.com/docs/installation) first.
+Before running these commands, make sure you are inside a React app that is already set up for Tailwind CSS and `shadcn/ui`. If your app is not ready yet, follow the [shadcn installation guide](https://ui.shadcn.com/docs/installation) first.
 
-Then install the WallRun components you need:
+Run the following commands from the root of that prepared app:
 
 ```bash
 # Install one component

--- a/libs/storybook-host/src/Introduction.mdx
+++ b/libs/storybook-host/src/Introduction.mdx
@@ -15,7 +15,11 @@ You can use this Storybook in two ways:
 
 ## Install From The Published Registry
 
-If you do not need the full monorepo, install individual signage components from the published registry:
+If you do not need the full monorepo, install individual signage components from the published registry.
+
+Before you run these commands, start from an app that already has Tailwind and the shadcn CLI set up. If you have not done that yet, follow the [shadcn installation guide](https://ui.shadcn.com/docs/installation) first.
+
+Then install the WallRun components you need:
 
 ```bash
 # Install one component
@@ -145,4 +149,4 @@ The other libraries in this Storybook support the broader WallRun workspace:
 
 Start in `Signage` unless you are working on the website rather than the display content.
 
-If you want the detailed install workflow next, read `Getting Started`. If you want the full WallRun workspace rather than copied components, use the GitHub repository link in `Resources`.
+If you want the detailed install workflow next, read [Getting Started](?path=/docs/getting-started--documentation). If you want the full WallRun workspace rather than copied components, use [Resources](?path=/docs/resources--documentation).

--- a/libs/storybook-host/src/Introduction.mdx
+++ b/libs/storybook-host/src/Introduction.mdx
@@ -8,6 +8,25 @@ WallRun is a component library and demo surface for building digital signage as 
 
 The primary library is `@wallrun/shadcnui-signage`. It is built for full-screen layouts, known resolutions, distance readability, and always-on operation on hardware such as BrightSign players.
 
+You can use this Storybook in two ways:
+
+- as composition guidance when you are working inside the WallRun workspace
+- as installation guidance when you want to add specific signage components to an existing React app through the published shadcn registry
+
+## Install From The Published Registry
+
+If you do not need the full monorepo, install individual signage components from the published registry:
+
+```bash
+# Install one component
+npx shadcn@latest add https://cambridgemonorail.github.io/WallRun/registry/registry.json clock
+
+# Install several components at once
+npx shadcn@latest add https://cambridgemonorail.github.io/WallRun/registry/registry.json metric-card event-card schedule-gate
+```
+
+These components are copied into your application codebase. They are not installed as a locked runtime package, so you can edit them freely once added.
+
 ## What This Storybook Is For
 
 Use this Storybook to answer three practical questions:
@@ -125,3 +144,5 @@ The other libraries in this Storybook support the broader WallRun workspace:
 - `@wallrun/landing` and `@wallrun/shell` support the demo website chrome rather than signage content itself.
 
 Start in `Signage` unless you are working on the website rather than the display content.
+
+If you want the detailed install workflow next, read `Getting Started`. If you want the full WallRun workspace rather than copied components, use the GitHub repository link in `Resources`.

--- a/libs/storybook-host/src/Resources.mdx
+++ b/libs/storybook-host/src/Resources.mdx
@@ -6,6 +6,27 @@ import { Meta } from '@storybook/addon-docs/blocks';
 
 ## Documentation
 
+### Install WallRun Components
+
+If you are here to add signage components to an existing app, start here.
+
+- [Published Registry](https://cambridgemonorail.github.io/WallRun/registry/registry.json) - Source for `npx shadcn@latest add ...`
+- [shadcn CLI Installation Docs](https://ui.shadcn.com/docs/installation) - CLI setup and usage reference
+
+Single-component install:
+
+```bash
+npx shadcn@latest add https://cambridgemonorail.github.io/WallRun/registry/registry.json clock
+```
+
+Multi-component install:
+
+```bash
+npx shadcn@latest add https://cambridgemonorail.github.io/WallRun/registry/registry.json metric-card event-card schedule-gate
+```
+
+WallRun registry installs copy components into your project. They are intended to be modified after installation rather than treated as an opaque runtime dependency.
+
 ### Project Documentation
 
 - [GitHub Repository](https://github.com/CambridgeMonorail/WallRun) - Source code, issues, and contributions


### PR DESCRIPTION
## Summary

Closes the Storybook documentation gap tracked in #76 by adding the published shadcn registry install workflow to the Storybook docs surfaces where new users actually look first.

### What changed

- added published registry install guidance to `libs/storybook-host/src/Introduction.mdx`
- added single and multi-component install examples to `libs/storybook-host/src/GettingStarted.mdx`
- clarified that registry installs copy components into the consumer codebase and can be modified freely
- made `libs/storybook-host/src/Resources.mdx` more discoverable for first-time users by moving the install path ahead of generic project links and renaming the section to `Install WallRun Components`
- added a plan note in `docs/plans/2026-05-02-storybook-registry-install-docs.md`

## Why

The client docs already explained how to install WallRun signage components from the published registry, but Storybook still framed the library only as a workspace/composition surface. That left a first-time user without a clear answer to the practical question: how do I add these components to my app?

This PR brings Storybook into parity with the existing client-side guidance and makes the install path discoverable from:

- `Introduction`
- `Getting Started`
- `Resources`

## Validation

### Docs checks

- verified Storybook renders:
  - `http://localhost:4400/?path=/docs/introduction--documentation`
  - `http://localhost:4400/?path=/docs/getting-started--documentation`
  - `http://localhost:4400/?path=/docs/resources--documentation`
- verified the `Introduction` page includes the published registry section and both install examples
- verified the `Getting Started` page includes existing-app install guidance and ownership language
- verified the `Resources` page now surfaces install guidance ahead of generic project links

### Diagnostics

- no editor diagnostics in the edited MDX files
- no markdown lint issues in the added plan note

Closes #76
