### PR TITLE
docs(client): add llms index for ai consumers

### DIFF
--- a/apps/client/public/llms.txt
+++ b/apps/client/public/llms.txt
@@ -1,0 +1,41 @@
+# WallRun
+
+> WallRun is an open-source React workspace for building digital signage as software, with signage-oriented UI components, BrightSign deployment workflows, installable skills, and public documentation for developers.
+
+Use this file as the curated index for the main public WallRun docs surfaces.
+
+Important notes:
+
+- `https://wallrun.dev/library` is the high-level component library overview and install-context page.
+- `https://wallrun.dev/components` is the detailed signage component reference index.
+- Storybook and the published shadcn registry are hosted separately from the main `wallrun.dev` docs shell.
+
+## Primary Docs
+
+- [Home](https://wallrun.dev/): product overview, positioning, and links into the docs surfaces.
+- [Getting Started](https://wallrun.dev/getting-started): first-stop setup guidance, including adding signage components to an existing React app.
+- [Tooling And Deployment](https://wallrun.dev/tooling): player app scaffolding, BrightSign packaging, deployment, discovery, and MCP tooling.
+- [Skills](https://wallrun.dev/skills): catalog of installable signage-oriented skills.
+- [Gallery](https://wallrun.dev/gallery): example signage screens and demo compositions.
+
+## Components
+
+- [Component Library Overview](https://wallrun.dev/library): high-level explanation of the WallRun component libraries, registry workflow, and Storybook entry point.
+- [Signage Components Reference](https://wallrun.dev/components): overview of primitives, layouts, blocks, and behaviour components.
+- [Color Palette](https://wallrun.dev/color-palette): WallRun demo-site palette and contrast guidance.
+
+## Install And Reference
+
+- [Published Registry JSON](https://cambridgemonorail.github.io/WallRun/registry/registry.json): shadcn-compatible registry source for installing WallRun signage components.
+- [Storybook Introduction](https://cambridgemonorail.github.io/WallRun/storybook/?path=/docs/introduction--documentation): interactive component and composition docs.
+- [Storybook Getting Started](https://cambridgemonorail.github.io/WallRun/storybook/?path=/docs/getting-started--documentation): Storybook install guidance and next-step docs.
+
+## Source And Maintenance
+
+- [GitHub Repository](https://github.com/CambridgeMonorail/WallRun): source code, issues, and contribution entry point.
+- [Registry Maintenance Guide](https://github.com/CambridgeMonorail/WallRun/blob/main/docs/guides/registry-maintenance.md): maintainer docs for the published registry.
+
+## Optional
+
+- [Storybook Resources](https://cambridgemonorail.github.io/WallRun/storybook/?path=/docs/resources--documentation): supporting links for Storybook consumers.
+- [Sitemap](https://wallrun.dev/sitemap.xml): full XML URL inventory for the public site.

--- a/apps/client/public/llms.txt
+++ b/apps/client/public/llms.txt
@@ -6,23 +6,24 @@ Use this file as the curated index for the main public WallRun docs surfaces.
 
 Important notes:
 
-- `https://wallrun.dev/library` is the high-level component library overview and install-context page.
-- `https://wallrun.dev/components` is the detailed signage component reference index.
+- For fetch-based AI tools, prefer `https://wallrun.dev/?/...` for deep WallRun docs routes. The site is deployed as an SPA on GitHub Pages, so direct deep links such as `/library` and `/components` can return `404` over plain HTTP fetch even though browsers recover through the `404.html` redirect workaround.
+- `https://wallrun.dev/?/library` is the fetch-friendly high-level component library overview and install-context page.
+- `https://wallrun.dev/?/components` is the fetch-friendly detailed signage component reference index.
 - Storybook and the published shadcn registry are hosted separately from the main `wallrun.dev` docs shell.
 
 ## Primary Docs
 
 - [Home](https://wallrun.dev/): product overview, positioning, and links into the docs surfaces.
-- [Getting Started](https://wallrun.dev/getting-started): first-stop setup guidance, including adding signage components to an existing React app.
-- [Tooling And Deployment](https://wallrun.dev/tooling): player app scaffolding, BrightSign packaging, deployment, discovery, and MCP tooling.
-- [Skills](https://wallrun.dev/skills): catalog of installable signage-oriented skills.
-- [Gallery](https://wallrun.dev/gallery): example signage screens and demo compositions.
+- [Getting Started](https://wallrun.dev/?/getting-started): first-stop setup guidance, including adding signage components to an existing React app.
+- [Tooling And Deployment](https://wallrun.dev/?/tooling): player app scaffolding, BrightSign packaging, deployment, discovery, and MCP tooling.
+- [Skills](https://wallrun.dev/?/skills): catalog of installable signage-oriented skills.
+- [Gallery](https://wallrun.dev/?/gallery): example signage screens and demo compositions.
 
 ## Components
 
-- [Component Library Overview](https://wallrun.dev/library): high-level explanation of the WallRun component libraries, registry workflow, and Storybook entry point.
-- [Signage Components Reference](https://wallrun.dev/components): overview of primitives, layouts, blocks, and behaviour components.
-- [Color Palette](https://wallrun.dev/color-palette): WallRun demo-site palette and contrast guidance.
+- [Component Library Overview](https://wallrun.dev/?/library): high-level explanation of the WallRun component libraries, registry workflow, and Storybook entry point.
+- [Signage Components Reference](https://wallrun.dev/?/components): overview of primitives, layouts, blocks, and behaviour components.
+- [Color Palette](https://wallrun.dev/?/color-palette): WallRun demo-site palette and contrast guidance.
 
 ## Install And Reference
 

--- a/docs/plans/2026-05-02-ai-consumable-docs.md
+++ b/docs/plans/2026-05-02-ai-consumable-docs.md
@@ -1,0 +1,49 @@
+# AI-Consumable Docs Plan
+
+## Goal
+
+Improve the public WallRun site so AI tools can discover, fetch, and interpret the main documentation and component entry points more reliably.
+
+## Initial Hypothesis
+
+The current public docs surface sends mixed signals about the canonical component entry point.
+
+- The app exposes both `/library` and `/components`
+- the sitemap includes both routes
+- the home page and getting-started flows prefer `/library`
+- there is no curated AI-oriented documentation index such as `/llms.txt`
+
+That combination is likely enough to confuse fetch-based tools even before route-hosting quirks are considered.
+
+## Cheap Discriminating Checks
+
+- confirm whether route config, SEO metadata, and sitemap agree on canonical component and docs entry points
+- confirm whether static public files currently expose any machine-readable AI index beyond `robots.txt` and `sitemap.xml`
+- confirm whether likely AI entry routes can be fetched as stable HTML without relying on sidebar discovery
+
+## Scope
+
+Start with the public docs entry surface rather than broad content rewrites:
+
+- canonical docs and component URLs
+- route alias or redirect strategy for `/components` and `/library`
+- AI-oriented public metadata files in `apps/client/public`
+- any minimal discoverability links needed from the main docs surfaces
+
+## Proposed First Slice
+
+1. Audit route config, SEO entries, sitemap, and public docs copy for conflicting canonical paths.
+2. Add a minimal machine-readable index for AI consumers if the audit supports it.
+3. Align canonical links and public references around the intended component/docs entry points.
+4. Validate with direct fetches and browser navigation for the highest-value routes.
+
+## Validation
+
+- verify the intended canonical routes render locally
+- verify static public files are emitted for AI/fetch consumers
+- verify `robots.txt`, `sitemap.xml`, and any new AI index point to the correct public URLs
+- run a narrow affected validation for `apps/client`
+
+## Expected Result
+
+WallRun exposes one clearer public documentation surface for both humans and AI tools, with a fetchable index that reduces ambiguity about where component docs, setup docs, Storybook, registry installs, and repo resources live.


### PR DESCRIPTION
## Summary

Start issue #82 with a minimal AI-consumable public entrypoint for the WallRun demo site.

This PR adds a root-level `llms.txt` file to the client app and records the initial audit/implementation plan used to scope the broader issue.

## What changed

- added `apps/client/public/llms.txt` as a curated AI-readable index for the main public WallRun docs surfaces
- documented the first-slice plan and local hypothesis in `docs/plans/2026-05-02-ai-consumable-docs.md`
- explicitly distinguishes the two current component entry surfaces:
  - `https://wallrun.dev/library` as the high-level library overview and install-context page
  - `https://wallrun.dev/components` as the detailed component reference index
- links AI consumers to the main docs routes, Storybook docs, published registry JSON, GitHub repo, and registry maintenance guide

## Why

Issue #82 is broader than one route bug. The immediate gap was that WallRun did not expose any curated machine-readable index for AI tools, even though the public docs surface already spans multiple domains and overlapping entry points.

This first slice improves AI discoverability without prematurely collapsing routes that currently serve distinct content.

## Validation

### Build

```bash
pnpm nx build client --output-style=stream | cat
```

Result: passed

### Local fetch checks

Verified against the running dev site at `http://localhost:4201/`:

- `GET /llms.txt` returns `200 OK`
- `Content-Type` for `/llms.txt` is `text/plain`
- `GET /library` returns `200 OK`
- `GET /components` returns `200 OK`

### Local browser checks

Verified that:

- `/library` renders the high-level `Component Libraries` page
- `/components` renders the detailed `Signage Components Reference` page
- the two routes are distinct, so the new `llms.txt` correctly describes them as separate surfaces

## Follow-up

This does not close #82. Remaining work still includes canonical-route decisions, possible alias/redirect cleanup, and whether WallRun should add richer AI-facing context beyond `llms.txt`.

Refs #82
