### PR TITLE
docs(client): add ai-readable doc surfaces

### DIFF
--- a/apps/client/public/ai-context.md
+++ b/apps/client/public/ai-context.md
@@ -1,0 +1,70 @@
+# WallRun AI Context
+
+WallRun is an open-source React workspace for building digital signage as software.
+
+The project combines:
+
+- signage-oriented React components
+- fixed-aspect layout and behaviour primitives
+- BrightSign packaging and deployment workflows
+- installable skills for AI-assisted signage engineering
+- a public demo/docs site plus Storybook and shadcn registry distribution
+
+## Canonical Machine Interfaces
+
+- `https://wallrun.dev/llms.txt`: curated index for AI consumers
+- `https://wallrun.dev/library.md`: high-level library overview
+- `https://wallrun.dev/components.md`: installable component catalogue
+- `https://cambridgemonorail.github.io/WallRun/registry/registry.json`: shadcn registry source
+- `https://cambridgemonorail.github.io/WallRun/storybook/?path=/docs/introduction--documentation`: interactive docs
+
+## Canonical Human Interfaces
+
+- `https://wallrun.dev/`
+- `https://wallrun.dev/getting-started`
+- `https://wallrun.dev/tooling`
+- `https://wallrun.dev/library`
+- `https://wallrun.dev/components`
+- `https://wallrun.dev/gallery`
+
+## Hosting Notes
+
+The main site is currently deployed as a static SPA on GitHub Pages.
+
+- browser navigation can recover deep routes through the SPA `404.html` redirect workaround
+- plain HTTP fetches to deep routes such as `/library` and `/components` can still return `404`
+- static files such as `llms.txt`, `library.md`, `components.md`, and `ai-context.md` return `HTTP 200` directly and should be preferred by agents and crawlers
+
+## Project Model
+
+- `library` explains what the libraries are and how they fit together
+- `components` explains the installable signage surface
+- `registry` provides the executable install source for shadcn tooling
+- `Storybook` provides interactive human docs and composition examples
+
+## When To Use WallRun
+
+Use WallRun when you need:
+
+- distance-readable digital signage components
+- predictable fixed-layout screen composition
+- behaviour primitives for unattended, always-on displays
+- BrightSign-targeted packaging and deployment workflows
+- an AI-assisted signage development workflow with portable skills and MCP tooling
+
+## When Not To Use WallRun
+
+WallRun is not the right fit if you need:
+
+- a no-code CMS or drag-and-drop signage builder
+- a generic responsive web marketing site
+- a runtime package that hides component code from the consuming app
+- a hosted SaaS platform for signage operations
+
+## Key Docs For Agents
+
+- `library.md` for library-level context
+- `components.md` for installable component details
+- `llms.txt` for the top-level map
+- `docs/guides/registry-maintenance.md` in the repository for maintainer workflow
+- `docs/guides/brightsign-deployment.md` in the repository for deployment guidance

--- a/apps/client/public/components.md
+++ b/apps/client/public/components.md
@@ -1,0 +1,333 @@
+# WallRun Components
+
+This file is the machine-readable component catalogue for the installable WallRun signage surface.
+
+## How To Use This File
+
+- Use this file when you need the install command, source path, runtime dependencies, or component fit.
+- Use `library.md` for high-level context about how the libraries relate.
+- Use the published registry JSON as the executable install source.
+
+Registry JSON:
+
+- `https://cambridgemonorail.github.io/WallRun/registry/registry.json`
+
+Install command pattern:
+
+```bash
+npx shadcn@latest add https://cambridgemonorail.github.io/WallRun/registry/registry.json <component-name>
+```
+
+## Catalogue
+
+### Metric Card
+
+- Name: `metric-card`
+- Category: Primitive
+- Purpose: KPI and numeric status display for dashboards and operations screens.
+- Install: `npx shadcn@latest add https://cambridgemonorail.github.io/WallRun/registry/registry.json metric-card`
+- Usage guidance: use for concise values, deltas, and icon-backed metric highlights.
+- Do not use for: long narrative copy, schedules, or multi-row lists.
+- Dependencies: `clsx`, `lucide-react`, `tailwind-merge`
+- Source path: `libs/shadcnui-signage/src/lib/primitives/MetricCard.tsx`
+- Registry JSON: `https://cambridgemonorail.github.io/WallRun/registry/registry.json`
+
+### Screen Frame
+
+- Name: `screen-frame`
+- Category: Primitive
+- Purpose: preview container with aspect-ratio and safe-area guides for development and QA.
+- Install: `npx shadcn@latest add https://cambridgemonorail.github.io/WallRun/registry/registry.json screen-frame`
+- Usage guidance: use in demos, previews, QA tools, and authoring workflows.
+- Do not use for: the real production screen shell of a deployed signage app.
+- Dependencies: none
+- Source path: `libs/shadcnui-signage/src/lib/primitives/ScreenFrame.tsx`
+- Registry JSON: `https://cambridgemonorail.github.io/WallRun/registry/registry.json`
+
+### Event Card
+
+- Name: `event-card`
+- Category: Primitive
+- Purpose: event, schedule, and conference slot card with time, speaker, and location metadata.
+- Install: `npx shadcn@latest add https://cambridgemonorail.github.io/WallRun/registry/registry.json event-card`
+- Usage guidance: use for schedule boards and venue/event programming.
+- Do not use for: KPI summaries or alert-heavy fallback states.
+- Dependencies: `clsx`, `lucide-react`, `tailwind-merge`
+- Source path: `libs/shadcnui-signage/src/lib/primitives/EventCard.tsx`
+- Registry JSON: `https://cambridgemonorail.github.io/WallRun/registry/registry.json`
+
+### Announcement Card
+
+- Name: `announcement-card`
+- Category: Primitive
+- Purpose: headline-and-description announcement card for notices and updates.
+- Install: `npx shadcn@latest add https://cambridgemonorail.github.io/WallRun/registry/registry.json announcement-card`
+- Usage guidance: use for announcements, alerts, and short informational messages.
+- Do not use for: dense tabular content or operational lists.
+- Dependencies: `clsx`, `lucide-react`, `tailwind-merge`
+- Source path: `libs/shadcnui-signage/src/lib/primitives/AnnouncementCard.tsx`
+- Registry JSON: `https://cambridgemonorail.github.io/WallRun/registry/registry.json`
+
+### Directory Card
+
+- Name: `directory-card`
+- Category: Primitive
+- Purpose: wayfinding card with department, floor, room, and contact metadata.
+- Install: `npx shadcn@latest add https://cambridgemonorail.github.io/WallRun/registry/registry.json directory-card`
+- Usage guidance: use for directory walls, office lobbies, and room-finding screens.
+- Do not use for: menu boards or event timeline cards.
+- Dependencies: `clsx`, `tailwind-merge`
+- Source path: `libs/shadcnui-signage/src/lib/primitives/DirectoryCard.tsx`
+- Registry JSON: `https://cambridgemonorail.github.io/WallRun/registry/registry.json`
+
+### Floor Badge
+
+- Name: `floor-badge`
+- Category: Primitive
+- Purpose: compact floor or zone label for wayfinding overlays.
+- Install: `npx shadcn@latest add https://cambridgemonorail.github.io/WallRun/registry/registry.json floor-badge`
+- Usage guidance: use as supporting location metadata inside wayfinding layouts.
+- Do not use for: primary page titles or large CTA states.
+- Dependencies: `clsx`, `tailwind-merge`
+- Source path: `libs/shadcnui-signage/src/lib/primitives/FloorBadge.tsx`
+- Registry JSON: `https://cambridgemonorail.github.io/WallRun/registry/registry.json`
+
+### Location Indicator
+
+- Name: `location-indicator`
+- Category: Primitive
+- Purpose: current-location marker with pin-style iconography for maps and directories.
+- Install: `npx shadcn@latest add https://cambridgemonorail.github.io/WallRun/registry/registry.json location-indicator`
+- Usage guidance: use as contextual location state inside wayfinding UIs.
+- Do not use for: destination lists or schedule rows.
+- Dependencies: `clsx`, `lucide-react`, `tailwind-merge`
+- Source path: `libs/shadcnui-signage/src/lib/primitives/LocationIndicator.tsx`
+- Registry JSON: `https://cambridgemonorail.github.io/WallRun/registry/registry.json`
+
+### Menu Item
+
+- Name: `menu-item`
+- Category: Primitive
+- Purpose: menu row with name, price, and optional description.
+- Install: `npx shadcn@latest add https://cambridgemonorail.github.io/WallRun/registry/registry.json menu-item`
+- Usage guidance: use inside restaurant, cafe, and concessions menu sections.
+- Do not use for: generic ecommerce cards or schedule cards.
+- Dependencies: `clsx`, `tailwind-merge`
+- Source path: `libs/shadcnui-signage/src/lib/primitives/MenuItem.tsx`
+- Registry JSON: `https://cambridgemonorail.github.io/WallRun/registry/registry.json`
+
+### Menu Section
+
+- Name: `menu-section`
+- Category: Primitive
+- Purpose: grouped section wrapper for menu categories.
+- Install: `npx shadcn@latest add https://cambridgemonorail.github.io/WallRun/registry/registry.json menu-section`
+- Usage guidance: use to group related menu items with a visible heading and divider.
+- Do not use for: dashboards or directory panels.
+- Dependencies: `clsx`, `tailwind-merge`
+- Source path: `libs/shadcnui-signage/src/lib/primitives/MenuSection.tsx`
+- Registry JSON: `https://cambridgemonorail.github.io/WallRun/registry/registry.json`
+
+### Signage Panel
+
+- Name: `signage-panel`
+- Category: Primitive
+- Purpose: bordered content panel for grouped supporting information.
+- Install: `npx shadcn@latest add https://cambridgemonorail.github.io/WallRun/registry/registry.json signage-panel`
+- Usage guidance: use for side panels, support zones, and secondary information blocks.
+- Do not use for: full-screen hero messaging.
+- Dependencies: `clsx`, `tailwind-merge`
+- Source path: `libs/shadcnui-signage/src/lib/primitives/SignagePanel.tsx`
+- Registry JSON: `https://cambridgemonorail.github.io/WallRun/registry/registry.json`
+
+### Meeting Row
+
+- Name: `meeting-row`
+- Category: Primitive
+- Purpose: agenda-style row for room booking and meeting schedules.
+- Install: `npx shadcn@latest add https://cambridgemonorail.github.io/WallRun/registry/registry.json meeting-row`
+- Usage guidance: use in operational schedules and office lobby meeting lists.
+- Do not use for: hero states or menu pricing.
+- Dependencies: `clsx`, `tailwind-merge`
+- Source path: `libs/shadcnui-signage/src/lib/primitives/MeetingRow.tsx`
+- Registry JSON: `https://cambridgemonorail.github.io/WallRun/registry/registry.json`
+
+### Info List
+
+- Name: `info-list`
+- Category: Primitive
+- Purpose: large-format list for notices, visitor instructions, and operational notes.
+- Install: `npx shadcn@latest add https://cambridgemonorail.github.io/WallRun/registry/registry.json info-list`
+- Usage guidance: use for short, glanceable bullet-style information.
+- Do not use for: metric-heavy dashboards or event grids.
+- Dependencies: `clsx`, `tailwind-merge`
+- Source path: `libs/shadcnui-signage/src/lib/primitives/InfoList.tsx`
+- Registry JSON: `https://cambridgemonorail.github.io/WallRun/registry/registry.json`
+
+### Split Screen
+
+- Name: `split-screen`
+- Category: Layout
+- Purpose: two-panel layout with configurable ratio and direction.
+- Install: `npx shadcn@latest add https://cambridgemonorail.github.io/WallRun/registry/registry.json split-screen`
+- Usage guidance: use for paired content zones on known display resolutions.
+- Do not use for: highly dynamic responsive webpage layouts.
+- Dependencies: `clsx`, `tailwind-merge`
+- Source path: `libs/shadcnui-signage/src/lib/layouts/SplitScreen.tsx`
+- Registry JSON: `https://cambridgemonorail.github.io/WallRun/registry/registry.json`
+
+### Signage Container
+
+- Name: `signage-container`
+- Category: Layout
+- Purpose: full-screen container with variant styling, ambient orbs, and optional grid treatment.
+- Install: `npx shadcn@latest add https://cambridgemonorail.github.io/WallRun/registry/registry.json signage-container`
+- Usage guidance: use as the main app-facing shell for real signage screens.
+- Do not use for: preview-only framing; use `screen-frame` for that.
+- Dependencies: `clsx`, `tailwind-merge`
+- Source path: `libs/shadcnui-signage/src/lib/layouts/SignageContainer.tsx`
+- Registry JSON: `https://cambridgemonorail.github.io/WallRun/registry/registry.json`
+
+### Signage Header
+
+- Name: `signage-header`
+- Category: Layout
+- Purpose: standard signage header with tag, title, and subtitle support.
+- Install: `npx shadcn@latest add https://cambridgemonorail.github.io/WallRun/registry/registry.json signage-header`
+- Usage guidance: use for page-level framing and hierarchy at the top of a screen.
+- Do not use for: compact card headers inside dense grids.
+- Dependencies: `clsx`, `tailwind-merge`
+- Source path: `libs/shadcnui-signage/src/lib/layouts/SignageHeader.tsx`
+- Registry JSON: `https://cambridgemonorail.github.io/WallRun/registry/registry.json`
+
+### Fullscreen Hero
+
+- Name: `fullscreen-hero`
+- Category: Block
+- Purpose: hero section for welcome states, alerts, and dominant messages.
+- Install: `npx shadcn@latest add https://cambridgemonorail.github.io/WallRun/registry/registry.json fullscreen-hero`
+- Usage guidance: use for main-message states where one headline dominates the screen.
+- Do not use for: multi-card dashboards or dense schedules.
+- Dependencies: `clsx`, `tailwind-merge`
+- Source path: `libs/shadcnui-signage/src/lib/blocks/FullscreenHero.tsx`
+- Registry JSON: `https://cambridgemonorail.github.io/WallRun/registry/registry.json`
+
+### Info Card Grid
+
+- Name: `info-card-grid`
+- Category: Block
+- Purpose: grid for small informational cards with values, descriptions, and meta text.
+- Install: `npx shadcn@latest add https://cambridgemonorail.github.io/WallRun/registry/registry.json info-card-grid`
+- Usage guidance: use for grouped promotional or summary cards where each item follows the same structure.
+- Do not use for: freeform card layouts with custom render requirements.
+- Dependencies: `clsx`, `tailwind-merge`
+- Source path: `libs/shadcnui-signage/src/lib/blocks/InfoCardGrid.tsx`
+- Registry JSON: `https://cambridgemonorail.github.io/WallRun/registry/registry.json`
+
+### Menu Board
+
+- Name: `menu-board`
+- Category: Block
+- Purpose: full-screen menu shell for restaurant and daypart signage.
+- Install: `npx shadcn@latest add https://cambridgemonorail.github.io/WallRun/registry/registry.json menu-board`
+- Usage guidance: use as the top-level shell for menu screens.
+- Do not use for: generic web page layouts or office dashboards.
+- Dependencies: `clsx`, `tailwind-merge`
+- Source path: `libs/shadcnui-signage/src/lib/blocks/MenuBoard.tsx`
+- Registry JSON: `https://cambridgemonorail.github.io/WallRun/registry/registry.json`
+
+### Auto Paging List
+
+- Name: `auto-paging-list`
+- Category: Behaviour
+- Purpose: paginate long lists without scrollbars, advancing automatically between pages.
+- Install: `npx shadcn@latest add https://cambridgemonorail.github.io/WallRun/registry/registry.json auto-paging-list`
+- Usage guidance: use when content exceeds a fixed display area but still needs calm unattended playback.
+- Do not use for: user-driven scrolling UIs.
+- Dependencies: `clsx`, `tailwind-merge`
+- Source path: `libs/shadcnui-signage/src/lib/behaviour/AutoPagingList.tsx`
+- Registry JSON: `https://cambridgemonorail.github.io/WallRun/registry/registry.json`
+
+### Content Rotator
+
+- Name: `content-rotator`
+- Category: Behaviour
+- Purpose: rotate through children on a fixed interval with signage-safe transitions.
+- Install: `npx shadcn@latest add https://cambridgemonorail.github.io/WallRun/registry/registry.json content-rotator`
+- Usage guidance: use for whole-state rotations such as lobby loops, promos, and announcement sequences.
+- Do not use for: fine-grained animation of individual inline elements.
+- Dependencies: `clsx`, `tailwind-merge`
+- Source path: `libs/shadcnui-signage/src/lib/behaviour/ContentRotator.tsx`
+- Registry JSON: `https://cambridgemonorail.github.io/WallRun/registry/registry.json`
+
+### Schedule Gate
+
+- Name: `schedule-gate`
+- Category: Behaviour
+- Purpose: weekday and time-window gating for daypart content.
+- Install: `npx shadcn@latest add https://cambridgemonorail.github.io/WallRun/registry/registry.json schedule-gate`
+- Usage guidance: use to swap or hide content based on known time windows and timezones.
+- Do not use for: arbitrary business rules unrelated to time/day scheduling.
+- Dependencies: `clsx`, `date-fns-tz`, `tailwind-merge`
+- Source path: `libs/shadcnui-signage/src/lib/behaviour/ScheduleGate.tsx`
+- Registry JSON: `https://cambridgemonorail.github.io/WallRun/registry/registry.json`
+
+### Signage Transition
+
+- Name: `signage-transition`
+- Category: Behaviour
+- Purpose: wrap a single child in signage-appropriate crossfade or slide transitions.
+- Install: `npx shadcn@latest add https://cambridgemonorail.github.io/WallRun/registry/registry.json signage-transition`
+- Usage guidance: use for explicit content-state transitions that should respect reduced motion.
+- Do not use for: continuous decorative motion.
+- Dependencies: `clsx`, `tailwind-merge`
+- Source path: `libs/shadcnui-signage/src/lib/behaviour/SignageTransition.tsx`
+- Registry JSON: `https://cambridgemonorail.github.io/WallRun/registry/registry.json`
+
+### Clock
+
+- Name: `clock`
+- Category: Behaviour
+- Purpose: current-time display with signage-friendly update cadence.
+- Install: `npx shadcn@latest add https://cambridgemonorail.github.io/WallRun/registry/registry.json clock`
+- Usage guidance: use for lobby, office, and status screens that need a visible clock.
+- Do not use for: countdown or elapsed-time flows.
+- Dependencies: `clsx`, `tailwind-merge`
+- Source path: `libs/shadcnui-signage/src/lib/behaviour/Clock.tsx`
+- Registry JSON: `https://cambridgemonorail.github.io/WallRun/registry/registry.json`
+
+### Countdown
+
+- Name: `countdown`
+- Category: Behaviour
+- Purpose: countdown to a target date/time with clamped zero state.
+- Install: `npx shadcn@latest add https://cambridgemonorail.github.io/WallRun/registry/registry.json countdown`
+- Usage guidance: use for events, deadlines, and timed launches.
+- Do not use for: current-time display.
+- Dependencies: `clsx`, `tailwind-merge`
+- Source path: `libs/shadcnui-signage/src/lib/behaviour/Countdown.tsx`
+- Registry JSON: `https://cambridgemonorail.github.io/WallRun/registry/registry.json`
+
+### Offline Fallback
+
+- Name: `offline-fallback`
+- Category: Behaviour
+- Purpose: fallback boundary for unhealthy or offline content.
+- Install: `npx shadcn@latest add https://cambridgemonorail.github.io/WallRun/registry/registry.json offline-fallback`
+- Usage guidance: use around network-backed content where a stable degraded state matters.
+- Do not use for: static content with no health or connectivity state.
+- Dependencies: `clsx`, `tailwind-merge`
+- Source path: `libs/shadcnui-signage/src/lib/behaviour/OfflineFallback.tsx`
+- Registry JSON: `https://cambridgemonorail.github.io/WallRun/registry/registry.json`
+
+### Stale Data Indicator
+
+- Name: `stale-data-indicator`
+- Category: Behaviour
+- Purpose: freshness indicator when a feed exceeds an allowed age threshold.
+- Install: `npx shadcn@latest add https://cambridgemonorail.github.io/WallRun/registry/registry.json stale-data-indicator`
+- Usage guidance: use beside live metrics, schedules, and operational feeds.
+- Do not use for: primary alert messaging; pair with more visible fallback UI when the whole screen is unhealthy.
+- Dependencies: `clsx`, `lucide-react`, `tailwind-merge`
+- Source path: `libs/shadcnui-signage/src/lib/behaviour/StaleDataIndicator.tsx`
+- Registry JSON: `https://cambridgemonorail.github.io/WallRun/registry/registry.json`

--- a/apps/client/public/library.md
+++ b/apps/client/public/library.md
@@ -1,0 +1,52 @@
+# WallRun Library
+
+WallRun publishes two related documentation surfaces for UI consumers:
+
+- `/library` is the human-facing overview of the component libraries, registry workflow, and Storybook entry points.
+- `/components` is the human-facing reference index for the installable signage catalogue.
+
+This markdown file is the machine-readable payload for the library overview.
+
+## What WallRun Ships
+
+- `@wallrun/shadcnui`: WallRun's copy of shadcn/ui building-block primitives for general web UI.
+- `@wallrun/shadcnui-signage`: signage-oriented components for fixed-aspect layouts, distance readability, and always-on displays.
+- Storybook docs: interactive composition and usage examples hosted at `https://cambridgemonorail.github.io/WallRun/storybook/`.
+- Published registry: installable signage components at `https://cambridgemonorail.github.io/WallRun/registry/registry.json`.
+
+## When To Use Each Surface
+
+- Use `library.md` when you need the high-level map: what the libraries are, how they relate, and where installation and Storybook fit.
+- Use `components.md` when you need the installable component catalogue, install commands, source paths, and package dependencies.
+- Use `ai-context.md` when you need a fuller machine-readable project summary including deployment, tooling, skills, and hosting notes.
+
+## Registry Workflow
+
+WallRun signage components are distributed through the shadcn registry protocol.
+
+- Install one component:
+
+```bash
+npx shadcn@latest add https://cambridgemonorail.github.io/WallRun/registry/registry.json clock
+```
+
+- Install several components:
+
+```bash
+npx shadcn@latest add https://cambridgemonorail.github.io/WallRun/registry/registry.json metric-card event-card schedule-gate
+```
+
+Registry installs copy component code into the consuming application. They are not version-locked runtime packages.
+
+## Primary Links
+
+- Human library route: `https://wallrun.dev/library`
+- Human components route: `https://wallrun.dev/components`
+- Machine component catalogue: `https://wallrun.dev/components.md`
+- Project context: `https://wallrun.dev/ai-context.md`
+- Registry JSON: `https://cambridgemonorail.github.io/WallRun/registry/registry.json`
+- Storybook docs: `https://cambridgemonorail.github.io/WallRun/storybook/?path=/docs/introduction--documentation`
+
+## Hosting Note
+
+The main `wallrun.dev` site is currently deployed as a static SPA on GitHub Pages. Human browser navigation can recover deep routes such as `/library` and `/components` through the SPA redirect workaround, but fetch-based tools should prefer static payloads such as `library.md`, `components.md`, `ai-context.md`, and `llms.txt` because those return `HTTP 200` directly.

--- a/apps/client/public/llms.txt
+++ b/apps/client/public/llms.txt
@@ -2,28 +2,33 @@
 
 > WallRun is an open-source React workspace for building digital signage as software, with signage-oriented UI components, BrightSign deployment workflows, installable skills, and public documentation for developers.
 
-Use this file as the curated index for the main public WallRun docs surfaces.
+Use this file as the curated index for the main public WallRun docs surfaces. Treat it as the map, not the payload.
 
 Important notes:
 
-- For fetch-based AI tools, prefer `https://wallrun.dev/?/...` for deep WallRun docs routes. The site is deployed as an SPA on GitHub Pages, so direct deep links such as `/library` and `/components` can return `404` over plain HTTP fetch even though browsers recover through the `404.html` redirect workaround.
-- `https://wallrun.dev/?/library` is the fetch-friendly high-level component library overview and install-context page.
-- `https://wallrun.dev/?/components` is the fetch-friendly detailed signage component reference index.
+- `wallrun.dev` currently serves a static SPA for humans and static `.md` / `.txt` files for machines.
+- For agents and fetch-based tools, prefer the static payloads below because they return `HTTP 200` without SPA route recovery.
 - Storybook and the published shadcn registry are hosted separately from the main `wallrun.dev` docs shell.
 
-## Primary Docs
+## Primary AI-Readable Docs
+
+- [Library Overview](https://wallrun.dev/library.md): high-level library map, registry workflow, and doc surface overview.
+- [Component Catalogue](https://wallrun.dev/components.md): installable signage component catalogue with install commands, fit guidance, dependencies, and source paths.
+- [Full Project Context](https://wallrun.dev/ai-context.md): project summary, hosting model, docs map, and machine-interface guidance.
+
+## Human Docs
 
 - [Home](https://wallrun.dev/): product overview, positioning, and links into the docs surfaces.
-- [Getting Started](https://wallrun.dev/?/getting-started): first-stop setup guidance, including adding signage components to an existing React app.
-- [Tooling And Deployment](https://wallrun.dev/?/tooling): player app scaffolding, BrightSign packaging, deployment, discovery, and MCP tooling.
-- [Skills](https://wallrun.dev/?/skills): catalog of installable signage-oriented skills.
-- [Gallery](https://wallrun.dev/?/gallery): example signage screens and demo compositions.
+- [Getting Started](https://wallrun.dev/getting-started): first-stop setup guidance, including adding signage components to an existing React app.
+- [Tooling And Deployment](https://wallrun.dev/tooling): player app scaffolding, BrightSign packaging, deployment, discovery, and MCP tooling.
+- [Skills](https://wallrun.dev/skills): catalog of installable signage-oriented skills.
+- [Gallery](https://wallrun.dev/gallery): example signage screens and demo compositions.
 
-## Components
+## Human Component Surfaces
 
-- [Component Library Overview](https://wallrun.dev/?/library): high-level explanation of the WallRun component libraries, registry workflow, and Storybook entry point.
-- [Signage Components Reference](https://wallrun.dev/?/components): overview of primitives, layouts, blocks, and behaviour components.
-- [Color Palette](https://wallrun.dev/?/color-palette): WallRun demo-site palette and contrast guidance.
+- [Component Library Overview](https://wallrun.dev/library): high-level explanation of the WallRun component libraries, registry workflow, and Storybook entry point.
+- [Signage Components Reference](https://wallrun.dev/components): overview of primitives, layouts, blocks, and behaviour components.
+- [Color Palette](https://wallrun.dev/color-palette): WallRun demo-site palette and contrast guidance.
 
 ## Install And Reference
 

--- a/apps/client/public/llms.txt
+++ b/apps/client/public/llms.txt
@@ -16,23 +16,25 @@ Important notes:
 - [Component Catalogue](https://wallrun.dev/components.md): installable signage component catalogue with install commands, fit guidance, dependencies, and source paths.
 - [Full Project Context](https://wallrun.dev/ai-context.md): project summary, hosting model, docs map, and machine-interface guidance.
 
-## Human Docs
+## Human Docs (Fetch-Safe Browser Routes)
 
 - [Home](https://wallrun.dev/): product overview, positioning, and links into the docs surfaces.
-- [Getting Started](https://wallrun.dev/getting-started): first-stop setup guidance, including adding signage components to an existing React app.
-- [Tooling And Deployment](https://wallrun.dev/tooling): player app scaffolding, BrightSign packaging, deployment, discovery, and MCP tooling.
-- [Skills](https://wallrun.dev/skills): catalog of installable signage-oriented skills.
-- [Gallery](https://wallrun.dev/gallery): example signage screens and demo compositions.
+- [Getting Started](https://wallrun.dev/?/getting-started): first-stop setup guidance, including adding signage components to an existing React app.
+- [Tooling And Deployment](https://wallrun.dev/?/tooling): player app scaffolding, BrightSign packaging, deployment, discovery, and MCP tooling.
+- [Skills](https://wallrun.dev/?/skills): catalog of installable signage-oriented skills.
+- [Gallery](https://wallrun.dev/?/gallery): example signage screens and demo compositions.
 
-## Human Component Surfaces
+These are still the human-facing React docs routes, but the `/?/...` form is listed here because it is the fetch-safe version on the current GitHub Pages deployment.
 
-- [Component Library Overview](https://wallrun.dev/library): high-level explanation of the WallRun component libraries, registry workflow, and Storybook entry point.
-- [Signage Components Reference](https://wallrun.dev/components): overview of primitives, layouts, blocks, and behaviour components.
-- [Color Palette](https://wallrun.dev/color-palette): WallRun demo-site palette and contrast guidance.
+## Human Component Surfaces (Fetch-Safe Browser Routes)
+
+- [Component Library Overview](https://wallrun.dev/?/library): high-level explanation of the WallRun component libraries, registry workflow, and Storybook entry point.
+- [Signage Components Reference](https://wallrun.dev/?/components): overview of primitives, layouts, blocks, and behaviour components.
+- [Color Palette](https://wallrun.dev/?/color-palette): WallRun demo-site palette and contrast guidance.
 
 ## Install And Reference
 
-- [Published Registry JSON](https://cambridgemonorail.github.io/WallRun/registry/registry.json): shadcn-compatible registry source for installing WallRun signage components.
+- [Published Registry JSON](https://wallrun.dev/registry/registry.json): shadcn-compatible registry source for installing WallRun signage components.
 - [Storybook Introduction](https://cambridgemonorail.github.io/WallRun/storybook/?path=/docs/introduction--documentation): interactive component and composition docs.
 - [Storybook Getting Started](https://cambridgemonorail.github.io/WallRun/storybook/?path=/docs/getting-started--documentation): Storybook install guidance and next-step docs.
 

--- a/apps/client/public/robots.txt
+++ b/apps/client/public/robots.txt
@@ -1,4 +1,5 @@
-# With custom domain wallrun.dev, robots.txt is now at the host root
+# WallRun allows crawling of human docs, machine-readable markdown payloads,
+# and the published registry JSON.
 
 User-agent: *
 Allow: /

--- a/apps/client/public/robots.txt
+++ b/apps/client/public/robots.txt
@@ -1,4 +1,4 @@
-# WallRun allows crawling of human docs, machine-readable markdown payloads,
+# WallRun allows crawling of human docs, machine-readable markdown payloads
 # and the published registry JSON.
 
 User-agent: *

--- a/apps/client/public/sitemap.xml
+++ b/apps/client/public/sitemap.xml
@@ -16,48 +16,6 @@
     <loc>https://wallrun.dev/ai-context.md</loc>
   </url>
   <url>
-    <loc>https://wallrun.dev/getting-started</loc>
-  </url>
-  <url>
-    <loc>https://wallrun.dev/tooling</loc>
-  </url>
-  <url>
-    <loc>https://wallrun.dev/library</loc>
-  </url>
-  <url>
-    <loc>https://wallrun.dev/gallery</loc>
-  </url>
-  <url>
-    <loc>https://wallrun.dev/components</loc>
-  </url>
-  <url>
-    <loc>https://wallrun.dev/color-palette</loc>
-  </url>
-  <url>
-    <loc>https://cambridgemonorail.github.io/WallRun/registry/registry.json</loc>
-  </url>
-  <url>
-    <loc>https://wallrun.dev/signage/welcome</loc>
-  </url>
-  <url>
-    <loc>https://wallrun.dev/signage/menu</loc>
-  </url>
-  <url>
-    <loc>https://wallrun.dev/signage/wayfinding</loc>
-  </url>
-  <url>
-    <loc>https://wallrun.dev/signage/dashboard</loc>
-  </url>
-  <url>
-    <loc>https://wallrun.dev/signage/announcements</loc>
-  </url>
-  <url>
-    <loc>https://wallrun.dev/signage/event-schedule</loc>
-  </url>
-  <url>
-    <loc>https://wallrun.dev/signage/office-lobby-loop</loc>
-  </url>
-  <url>
-    <loc>https://wallrun.dev/signage/daypart-menu</loc>
+    <loc>https://wallrun.dev/registry/registry.json</loc>
   </url>
 </urlset>

--- a/apps/client/public/sitemap.xml
+++ b/apps/client/public/sitemap.xml
@@ -4,6 +4,18 @@
     <loc>https://wallrun.dev/</loc>
   </url>
   <url>
+    <loc>https://wallrun.dev/llms.txt</loc>
+  </url>
+  <url>
+    <loc>https://wallrun.dev/library.md</loc>
+  </url>
+  <url>
+    <loc>https://wallrun.dev/components.md</loc>
+  </url>
+  <url>
+    <loc>https://wallrun.dev/ai-context.md</loc>
+  </url>
+  <url>
     <loc>https://wallrun.dev/getting-started</loc>
   </url>
   <url>
@@ -20,6 +32,9 @@
   </url>
   <url>
     <loc>https://wallrun.dev/color-palette</loc>
+  </url>
+  <url>
+    <loc>https://cambridgemonorail.github.io/WallRun/registry/registry.json</loc>
   </url>
   <url>
     <loc>https://wallrun.dev/signage/welcome</loc>


### PR DESCRIPTION
## Summary

Continue issue #82 by adding static AI-readable documentation payloads that return `HTTP 200` without relying on SPA route recovery.

This PR builds on the earlier `llms.txt` slice by making `llms.txt` the map and adding richer markdown payloads for the main documentation surfaces.

## What changed

- added `apps/client/public/library.md` as the machine-readable library overview
- added `apps/client/public/components.md` as the machine-readable installable component catalogue
- added `apps/client/public/ai-context.md` as a higher-level project and hosting context document
- updated `apps/client/public/llms.txt` to point agents at the new markdown payloads rather than treating route URLs as the primary machine interface
- updated `apps/client/public/sitemap.xml` to include the AI-readable markdown endpoints and the published registry JSON
- updated `apps/client/public/robots.txt` comments to reflect that markdown and registry assets are intended to be crawlable

## Why

The previous `#82` slice established `llms.txt`, but `llms.txt` alone is only a map. The deeper problem is that the human docs routes are still React SPA routes, while fetch-based tools need stable static payloads.

This PR establishes the durable machine interface:

- `llms.txt` for discovery
- `library.md` for high-level library context
- `components.md` for installable component details
- `ai-context.md` for project-level guidance and hosting notes

## Validation

### Build

```bash
pnpm nx build client --output-style=stream | cat
```

Result: passed

### Diagnostics

No editor diagnostics in:

- `apps/client/public/library.md`
- `apps/client/public/components.md`
- `apps/client/public/ai-context.md`
- `apps/client/public/llms.txt`
- `apps/client/public/sitemap.xml`
- `apps/client/public/robots.txt`

### Built asset checks

Verified the build output includes:

- `dist/apps/client/llms.txt`
- `dist/apps/client/library.md`
- `dist/apps/client/components.md`
- `dist/apps/client/ai-context.md`

## Follow-up

This still does not close #82. Remaining work likely includes whether the human docs routes should expose explicit alternate metadata links and whether route/canonical strategy should be tightened further.

Refs #82
