### PR TITLE
docs(client): add component docs parity for signage exports

### DIFF
--- a/apps/client/src/app/components/CodeSnippet.tsx
+++ b/apps/client/src/app/components/CodeSnippet.tsx
@@ -2,6 +2,10 @@ import { FC, useState } from 'react';
 import { Button } from '@wallrun/shadcnui';
 import { Check, Copy } from 'lucide-react';
 import { cn } from '@wallrun/shadcnui';
+import {
+  LEGACY_REGISTRY_URL,
+  PUBLIC_REGISTRY_URL,
+} from './componentDocs.constants';
 
 export interface CodeSnippetProps {
   /**
@@ -54,10 +58,11 @@ export const CodeSnippet: FC<CodeSnippetProps> = ({
   'data-testid': dataTestId = 'code-snippet',
 }) => {
   const [copied, setCopied] = useState(false);
+  const displayedCode = code.replaceAll(LEGACY_REGISTRY_URL, PUBLIC_REGISTRY_URL);
 
   const handleCopy = async () => {
     try {
-      await navigator.clipboard.writeText(code);
+      await navigator.clipboard.writeText(displayedCode);
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     } catch (err) {
@@ -65,7 +70,7 @@ export const CodeSnippet: FC<CodeSnippetProps> = ({
     }
   };
 
-  const lines = code.split('\n');
+  const lines = displayedCode.split('\n');
 
   return (
     <div
@@ -120,7 +125,7 @@ export const CodeSnippet: FC<CodeSnippetProps> = ({
               ))}
             </code>
           ) : (
-            <code data-language={language}>{code}</code>
+            <code data-language={language}>{displayedCode}</code>
           )}
         </pre>
       </div>

--- a/apps/client/src/app/components/ComponentDocTemplate.tsx
+++ b/apps/client/src/app/components/ComponentDocTemplate.tsx
@@ -1,6 +1,7 @@
 import { FC, ReactNode } from 'react';
 import { Button } from '@wallrun/shadcnui';
 import { CodeSnippet } from './CodeSnippet';
+import { PUBLIC_REGISTRY_URL } from './componentDocs.constants';
 
 type ComponentDocLink = {
   label: string;
@@ -89,7 +90,7 @@ export const ComponentDocTemplate: FC<ComponentDocTemplateProps> = ({
           <h3 className="mb-3 text-lg font-medium">Using the CLI (Recommended)</h3>
           <CodeSnippet
             language="bash"
-            code={`npx shadcn@latest add https://wallrun.dev/registry/registry.json ${installName}`}
+            code={`npx shadcn@latest add ${PUBLIC_REGISTRY_URL} ${installName}`}
           />
         </div>
 

--- a/apps/client/src/app/components/ComponentDocTemplate.tsx
+++ b/apps/client/src/app/components/ComponentDocTemplate.tsx
@@ -1,0 +1,169 @@
+import { FC, ReactNode } from 'react';
+import { Button } from '@wallrun/shadcnui';
+import { CodeSnippet } from './CodeSnippet';
+
+type ComponentDocLink = {
+  label: string;
+  href: string;
+};
+
+type ComponentDocNote = {
+  title: string;
+  body: string;
+};
+
+export interface ComponentDocTemplateProps {
+  category: string;
+  name: string;
+  description: string;
+  builtOnSummary: string;
+  builtOnPoints: string[];
+  example: ReactNode;
+  installName: string;
+  sourcePaths: string[];
+  dependencyInstall?: string;
+  usageCode: string;
+  usageFilename: string;
+  signageNotes: ComponentDocNote[];
+  links: ComponentDocLink[];
+}
+
+export const ComponentDocTemplate: FC<ComponentDocTemplateProps> = ({
+  category,
+  name,
+  description,
+  builtOnSummary,
+  builtOnPoints,
+  example,
+  installName,
+  sourcePaths,
+  dependencyInstall,
+  usageCode,
+  usageFilename,
+  signageNotes,
+  links,
+}) => {
+  return (
+    <div className="container mx-auto max-w-5xl px-4 py-8">
+      <div className="mb-10 space-y-4">
+        <p className="text-sm text-muted-foreground">{category}</p>
+
+        <h1 className="text-3xl font-medium tracking-tight md:text-4xl">
+          {name}
+        </h1>
+
+        <p className="max-w-2xl text-base text-muted-foreground md:text-lg">
+          {description}
+        </p>
+      </div>
+
+      <section className="mb-12">
+        <h2 className="mb-4 text-2xl font-medium">Built On</h2>
+        <div className="rounded-lg bg-muted p-6">
+          <p className="mb-4">
+            <strong>{builtOnSummary}</strong>
+          </p>
+          <ul className="list-inside list-disc space-y-2 text-muted-foreground">
+            {builtOnPoints.map((point) => (
+              <li key={point}>{point}</li>
+            ))}
+          </ul>
+        </div>
+      </section>
+
+      <section className="mb-12">
+        <h2 className="mb-4 text-2xl font-medium">Example</h2>
+        <div className="overflow-hidden rounded-lg bg-slate-950 p-8">
+          {example}
+        </div>
+      </section>
+
+      <section className="mb-12">
+        <h2 className="mb-4 text-2xl font-medium">Installation</h2>
+        <p className="mb-4 text-muted-foreground">
+          Copy the source code into your project, or install it from the public
+          WallRun registry.
+        </p>
+
+        <div className="mb-6">
+          <h3 className="mb-3 text-lg font-medium">Using the CLI (Recommended)</h3>
+          <CodeSnippet
+            language="bash"
+            code={`npx shadcn@latest add https://wallrun.dev/registry/registry.json ${installName}`}
+          />
+        </div>
+
+        <div className="mb-4">
+          <h3 className="mb-3 text-lg font-medium">Manual Installation</h3>
+        </div>
+        <div className="space-y-4">
+          <div>
+            <h3 className="mb-2 text-lg font-medium">1. Copy the source files</h3>
+            <div className="space-y-2 text-muted-foreground">
+              {sourcePaths.map((sourcePath) => {
+                const sourceUrl = `https://github.com/CambridgeMonorail/WallRun/blob/main/${sourcePath}`;
+
+                return (
+                  <p key={sourcePath}>
+                    <a
+                      href={sourceUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex min-h-11 items-center font-mono text-sm text-blue-400 hover:text-blue-300 hover:underline"
+                    >
+                      {sourcePath}
+                    </a>
+                  </p>
+                );
+              })}
+            </div>
+          </div>
+          <div>
+            <h3 className="mb-2 text-lg font-medium">2. Install dependencies</h3>
+            {dependencyInstall ? (
+              <CodeSnippet language="bash" code={dependencyInstall} />
+            ) : (
+              <p className="text-sm text-muted-foreground">
+                No additional dependencies required.
+              </p>
+            )}
+          </div>
+        </div>
+      </section>
+
+      <section className="mb-12">
+        <h2 className="mb-4 text-2xl font-medium">Usage</h2>
+        <CodeSnippet
+          language="tsx"
+          filename={usageFilename}
+          code={usageCode}
+        />
+      </section>
+
+      <section className="mb-12">
+        <h2 className="mb-4 text-2xl font-medium">Signage Considerations</h2>
+        <div className="space-y-4 text-muted-foreground">
+          {signageNotes.map((note) => (
+            <div key={note.title}>
+              <strong className="text-foreground">{note.title}:</strong>{' '}
+              {note.body}
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section>
+        <h2 className="mb-4 text-2xl font-medium">Links</h2>
+        <div className="flex flex-wrap gap-4">
+          {links.map((link) => (
+            <Button key={link.href} asChild variant="outline" className="h-11">
+              <a href={link.href} target="_blank" rel="noopener noreferrer">
+                {link.label}
+              </a>
+            </Button>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+};

--- a/apps/client/src/app/components/componentDocs.constants.ts
+++ b/apps/client/src/app/components/componentDocs.constants.ts
@@ -1,0 +1,5 @@
+export const PUBLIC_REGISTRY_URL =
+  'https://wallrun.dev/registry/registry.json';
+
+export const LEGACY_REGISTRY_URL =
+  'https://cambridgemonorail.github.io/WallRun/registry/registry.json';

--- a/apps/client/src/app/constants/navigationConfig.ts
+++ b/apps/client/src/app/constants/navigationConfig.ts
@@ -31,11 +31,20 @@ import { MetricCardDocPage } from '../pages/components/primitives/MetricCardDoc'
 import { ScreenFrameDocPage } from '../pages/components/primitives/ScreenFrameDoc';
 import { EventCardDocPage } from '../pages/components/primitives/EventCardDoc';
 import { AnnouncementCardDocPage } from '../pages/components/primitives/AnnouncementCardDoc';
+import { DirectoryCardDocPage } from '../pages/components/primitives/DirectoryCardDoc';
+import { FloorBadgeDocPage } from '../pages/components/primitives/FloorBadgeDoc';
+import { LocationIndicatorDocPage } from '../pages/components/primitives/LocationIndicatorDoc';
+import { MenuItemDocPage } from '../pages/components/primitives/MenuItemDoc';
+import { MenuSectionDocPage } from '../pages/components/primitives/MenuSectionDoc';
+import { SignagePanelDocPage } from '../pages/components/primitives/SignagePanelDoc';
+import { MeetingRowDocPage } from '../pages/components/primitives/MeetingRowDoc';
+import { InfoListDocPage } from '../pages/components/primitives/InfoListDoc';
 import { SplitScreenDocPage } from '../pages/components/layouts/SplitScreenDoc';
 import { SignageContainerDocPage } from '../pages/components/layouts/SignageContainerDoc';
 import { SignageHeaderDocPage } from '../pages/components/layouts/SignageHeaderDoc';
 import { FullscreenHeroDocPage } from '../pages/components/blocks/FullscreenHeroDoc';
 import { InfoCardGridDocPage } from '../pages/components/blocks/InfoCardGridDoc';
+import { MenuBoardDocPage } from '../pages/components/blocks/MenuBoardDoc';
 import { ContentRotatorDocPage } from '../pages/components/behaviour/ContentRotatorDoc';
 import { HowToPage } from '../pages/how-to/HowTo';
 import { CustomAgentsPage } from '../pages/how-to/CustomAgents';
@@ -87,6 +96,14 @@ const paths = {
       screenFrame: '/components/primitives/screen-frame',
       eventCard: '/components/primitives/event-card',
       announcementCard: '/components/primitives/announcement-card',
+      directoryCard: '/components/primitives/directory-card',
+      floorBadge: '/components/primitives/floor-badge',
+      locationIndicator: '/components/primitives/location-indicator',
+      menuItem: '/components/primitives/menu-item',
+      menuSection: '/components/primitives/menu-section',
+      signagePanel: '/components/primitives/signage-panel',
+      meetingRow: '/components/primitives/meeting-row',
+      infoList: '/components/primitives/info-list',
     },
     layouts: {
       splitScreen: '/components/layouts/split-screen',
@@ -96,6 +113,7 @@ const paths = {
     blocks: {
       fullscreenHero: '/components/blocks/fullscreen-hero',
       infoCardGrid: '/components/blocks/info-card-grid',
+      menuBoard: '/components/blocks/menu-board',
     },
     behaviour: {
       contentRotator: '/components/behaviour/content-rotator',
@@ -182,6 +200,20 @@ const sidebarData: SidebarConfiguration = {
           title: 'AnnouncementCard',
           url: paths.components.primitives.announcementCard,
         },
+        { title: 'DirectoryCard', url: paths.components.primitives.directoryCard },
+        { title: 'FloorBadge', url: paths.components.primitives.floorBadge },
+        {
+          title: 'LocationIndicator',
+          url: paths.components.primitives.locationIndicator,
+        },
+        { title: 'MenuItem', url: paths.components.primitives.menuItem },
+        { title: 'MenuSection', url: paths.components.primitives.menuSection },
+        {
+          title: 'SignagePanel',
+          url: paths.components.primitives.signagePanel,
+        },
+        { title: 'MeetingRow', url: paths.components.primitives.meetingRow },
+        { title: 'InfoList', url: paths.components.primitives.infoList },
         { title: 'SplitScreen', url: paths.components.layouts.splitScreen },
         {
           title: 'SignageContainer',
@@ -193,6 +225,7 @@ const sidebarData: SidebarConfiguration = {
           url: paths.components.blocks.fullscreenHero,
         },
         { title: 'InfoCardGrid', url: paths.components.blocks.infoCardGrid },
+        { title: 'MenuBoard', url: paths.components.blocks.menuBoard },
         {
           title: 'ContentRotator',
           url: paths.components.behaviour.contentRotator,
@@ -293,6 +326,17 @@ const routes = [
     paths.components.primitives.announcementCard,
     AnnouncementCardDocPage,
   ),
+  createRoute(paths.components.primitives.directoryCard, DirectoryCardDocPage),
+  createRoute(paths.components.primitives.floorBadge, FloorBadgeDocPage),
+  createRoute(
+    paths.components.primitives.locationIndicator,
+    LocationIndicatorDocPage,
+  ),
+  createRoute(paths.components.primitives.menuItem, MenuItemDocPage),
+  createRoute(paths.components.primitives.menuSection, MenuSectionDocPage),
+  createRoute(paths.components.primitives.signagePanel, SignagePanelDocPage),
+  createRoute(paths.components.primitives.meetingRow, MeetingRowDocPage),
+  createRoute(paths.components.primitives.infoList, InfoListDocPage),
   createRoute(paths.components.layouts.splitScreen, SplitScreenDocPage),
   createRoute(
     paths.components.layouts.signageContainer,
@@ -301,6 +345,7 @@ const routes = [
   createRoute(paths.components.layouts.signageHeader, SignageHeaderDocPage),
   createRoute(paths.components.blocks.fullscreenHero, FullscreenHeroDocPage),
   createRoute(paths.components.blocks.infoCardGrid, InfoCardGridDocPage),
+  createRoute(paths.components.blocks.menuBoard, MenuBoardDocPage),
   createRoute(paths.components.behaviour.contentRotator, ContentRotatorDocPage),
   createRoute(paths.components.behaviour.scheduleGate, ScheduleGateDocPage),
   createRoute(paths.components.behaviour.autoPagingList, AutoPagingListDocPage),

--- a/apps/client/src/app/pages/components/ComponentIndex.tsx
+++ b/apps/client/src/app/pages/components/ComponentIndex.tsx
@@ -37,6 +37,54 @@ const components: ComponentInfo[] = [
     description: 'Announcement cards for important messages and updates',
     category: 'Primitives',
   },
+  {
+    name: 'DirectoryCard',
+    path: '/components/primitives/directory-card',
+    description: 'Wayfinding card for departments, floors, rooms, and contacts',
+    category: 'Primitives',
+  },
+  {
+    name: 'FloorBadge',
+    path: '/components/primitives/floor-badge',
+    description: 'Compact floor marker for directories, maps, and wayfinding',
+    category: 'Primitives',
+  },
+  {
+    name: 'LocationIndicator',
+    path: '/components/primitives/location-indicator',
+    description: 'Current-location chip for wayfinding and directory headers',
+    category: 'Primitives',
+  },
+  {
+    name: 'MenuItem',
+    path: '/components/primitives/menu-item',
+    description: 'Price-led menu row with optional description and divider',
+    category: 'Primitives',
+  },
+  {
+    name: 'MenuSection',
+    path: '/components/primitives/menu-section',
+    description: 'Section wrapper for grouped menu content and headings',
+    category: 'Primitives',
+  },
+  {
+    name: 'SignagePanel',
+    path: '/components/primitives/signage-panel',
+    description: 'Bordered panel for grouped supporting information',
+    category: 'Primitives',
+  },
+  {
+    name: 'MeetingRow',
+    path: '/components/primitives/meeting-row',
+    description: 'Agenda row for meeting schedules and room bookings',
+    category: 'Primitives',
+  },
+  {
+    name: 'InfoList',
+    path: '/components/primitives/info-list',
+    description: 'Large-format list for instructions and operational notes',
+    category: 'Primitives',
+  },
   // Layouts
   {
     name: 'SplitScreen',
@@ -68,6 +116,12 @@ const components: ComponentInfo[] = [
     name: 'InfoCardGrid',
     path: '/components/blocks/info-card-grid',
     description: 'Grid layouts for displaying multiple information cards',
+    category: 'Blocks',
+  },
+  {
+    name: 'MenuBoard',
+    path: '/components/blocks/menu-board',
+    description: 'Full-screen composition shell for menu boards and daypart content',
     category: 'Blocks',
   },
   // Behaviour

--- a/apps/client/src/app/pages/components/blocks/MenuBoardDoc.tsx
+++ b/apps/client/src/app/pages/components/blocks/MenuBoardDoc.tsx
@@ -1,0 +1,97 @@
+import { FC } from 'react';
+import { ComponentDocTemplate } from '../../../components/ComponentDocTemplate';
+import { MenuBoard, MenuItem, MenuSection } from '@wallrun/shadcnui-signage';
+
+export const MenuBoardDocPage: FC = () => {
+  return (
+    <ComponentDocTemplate
+      category="Blocks"
+      name="MenuBoard"
+      description="Full-screen menu composition shell for restaurant, cafe, and daypart signage content."
+      builtOnSummary="Composed block built on SignageContainer with flexible header, content, and footer zones."
+      builtOnPoints={[
+        'Wraps menu content in a full-screen signage shell with branded background variants.',
+        'Supports eyebrow, title, subtitle, headerRight, and footer slots for rich menu layouts.',
+        'Pairs naturally with MenuSection and MenuItem for complete menu-board compositions.',
+      ]}
+      example={
+        <div style={{ height: '720px' }}>
+          <MenuBoard
+            eyebrow="DAYPART MENU"
+            title="Signal & Salt"
+            subtitle="Breakfast until 11:30"
+            footer={
+              <div className="mt-10 text-xl text-white/70">
+                Ask about allergen guidance at the counter.
+              </div>
+            }
+          >
+            <div className="grid gap-10 lg:grid-cols-2">
+              <MenuSection title="Breakfast" contentClassName="space-y-5">
+                <MenuItem name="Flat White + Pastry" price="$8" />
+                <MenuItem
+                  name="Citrus Granola Bowl"
+                  price="$10"
+                  description="Greek yoghurt, orange syrup, toasted seeds"
+                  hideDivider={true}
+                />
+              </MenuSection>
+              <MenuSection title="Warm Plates" contentClassName="space-y-5">
+                <MenuItem name="Herb Omelette" price="$12" />
+                <MenuItem
+                  name="Roast Tomato Toast"
+                  price="$11"
+                  description="Whipped feta and basil"
+                  hideDivider={true}
+                />
+              </MenuSection>
+            </div>
+          </MenuBoard>
+        </div>
+      }
+      installName="menu-board"
+      sourcePaths={[
+        'libs/shadcnui-signage/src/lib/blocks/MenuBoard.tsx',
+        'libs/shadcnui-signage/src/lib/layouts/SignageContainer.tsx',
+        'libs/shadcnui-signage/src/lib/utils/cn.ts',
+      ]}
+      dependencyInstall="pnpm add clsx tailwind-merge"
+      usageFilename="RestaurantMenu.tsx"
+      usageCode={`import { MenuBoard, MenuItem, MenuSection } from '@/components/signage';
+
+export function RestaurantMenu() {
+  return (
+    <MenuBoard title="Cafe" subtitle="Lunch from 12:00">
+      <MenuSection title="Specials" contentClassName="space-y-5">
+        <MenuItem name="Charred Corn Tacos" price="$15" hideDivider={true} />
+      </MenuSection>
+    </MenuBoard>
+  );
+}`}
+      signageNotes={[
+        {
+          title: 'Full-Screen Composition',
+          body: 'MenuBoard is meant to own the entire screen surface, not sit inside a small card or dashboard module.',
+        },
+        {
+          title: 'Header Flexibility',
+          body: 'Use the eyebrow and headerRight areas for daypart labels, service times, promos, or brand marks without rebuilding the shell.',
+        },
+        {
+          title: 'Menu Rhythm',
+          body: 'Pair it with MenuSection and MenuItem so the layout, typography, and spacing stay consistent across large-format menu screens.',
+        },
+      ]}
+      links={[
+        {
+          label: 'View Source',
+          href: 'https://github.com/CambridgeMonorail/WallRun/blob/main/libs/shadcnui-signage/src/lib/blocks/MenuBoard.tsx',
+        },
+        {
+          label: 'Library README',
+          href: 'https://github.com/CambridgeMonorail/WallRun/blob/main/libs/shadcnui-signage/README.md',
+        },
+      ]}
+    />
+  );
+};

--- a/apps/client/src/app/pages/components/blocks/MenuBoardDoc.tsx
+++ b/apps/client/src/app/pages/components/blocks/MenuBoardDoc.tsx
@@ -57,7 +57,9 @@ export const MenuBoardDocPage: FC = () => {
       ]}
       dependencyInstall="pnpm add clsx tailwind-merge"
       usageFilename="RestaurantMenu.tsx"
-      usageCode={`import { MenuBoard, MenuItem, MenuSection } from '@/components/signage';
+      usageCode={`import { MenuBoard } from '@/components/signage/blocks/MenuBoard';
+    import { MenuItem } from '@/components/signage/primitives/MenuItem';
+    import { MenuSection } from '@/components/signage/primitives/MenuSection';
 
 export function RestaurantMenu() {
   return (

--- a/apps/client/src/app/pages/components/primitives/DirectoryCardDoc.tsx
+++ b/apps/client/src/app/pages/components/primitives/DirectoryCardDoc.tsx
@@ -1,0 +1,73 @@
+import { FC } from 'react';
+import { ComponentDocTemplate } from '../../../components/ComponentDocTemplate';
+import { DirectoryCard } from '@wallrun/shadcnui-signage';
+
+export const DirectoryCardDocPage: FC = () => {
+  return (
+    <ComponentDocTemplate
+      category="Primitives"
+      name="DirectoryCard"
+      description="Wayfinding card for departments and destinations with floor, room, and contact metadata."
+      builtOnSummary="Custom signage card with FloorBadge and shared utility styling."
+      builtOnPoints={[
+        'Uses FloorBadge to emphasize the destination floor immediately.',
+        'Applies a bordered gradient panel for readable wayfinding zones.',
+        'Balances large department labels with room and phone metadata.',
+      ]}
+      example={
+        <div className="mx-auto max-w-3xl">
+          <DirectoryCard
+            department="Visitor Reception"
+            floor={2}
+            room="2.14"
+            phone="Ext. 204"
+          />
+        </div>
+      }
+      installName="directory-card"
+      sourcePaths={[
+        'libs/shadcnui-signage/src/lib/primitives/DirectoryCard.tsx',
+        'libs/shadcnui-signage/src/lib/primitives/FloorBadge.tsx',
+        'libs/shadcnui-signage/src/lib/utils/cn.ts',
+      ]}
+      dependencyInstall="pnpm add clsx tailwind-merge"
+      usageFilename="OfficeDirectory.tsx"
+      usageCode={`import { DirectoryCard } from '@/components/signage/primitives/DirectoryCard';
+
+export function OfficeDirectory() {
+  return (
+    <DirectoryCard
+      department="Design Studio"
+      floor={3}
+      room="3.08"
+      phone="Ext. 308"
+    />
+  );
+}`}
+      signageNotes={[
+        {
+          title: 'Distance Readability',
+          body: 'The department name and floor marker are sized for quick recognition from a lobby or corridor viewing distance.',
+        },
+        {
+          title: 'Wayfinding Hierarchy',
+          body: 'Use one card per destination or department so room and phone details stay secondary to the main location label.',
+        },
+        {
+          title: 'Flexible Placement',
+          body: 'The component works well in directory grids, reception callouts, and split-screen wayfinding layouts.',
+        },
+      ]}
+      links={[
+        {
+          label: 'View Source',
+          href: 'https://github.com/CambridgeMonorail/WallRun/blob/main/libs/shadcnui-signage/src/lib/primitives/DirectoryCard.tsx',
+        },
+        {
+          label: 'Library README',
+          href: 'https://github.com/CambridgeMonorail/WallRun/blob/main/libs/shadcnui-signage/README.md',
+        },
+      ]}
+    />
+  );
+};

--- a/apps/client/src/app/pages/components/primitives/FloorBadgeDoc.tsx
+++ b/apps/client/src/app/pages/components/primitives/FloorBadgeDoc.tsx
@@ -1,0 +1,62 @@
+import { FC } from 'react';
+import { ComponentDocTemplate } from '../../../components/ComponentDocTemplate';
+import { FloorBadge } from '@wallrun/shadcnui-signage';
+
+export const FloorBadgeDocPage: FC = () => {
+  return (
+    <ComponentDocTemplate
+      category="Primitives"
+      name="FloorBadge"
+      description="Compact floor marker for directories, maps, and lobby wayfinding screens."
+      builtOnSummary="Native HTML with shared cn utility and gradient badge styling."
+      builtOnPoints={[
+        'Uses bold rounded badge styling so floor numbers stand out immediately.',
+        'Keeps the footprint small enough for dense directory layouts.',
+        'Accepts string or numeric floor labels for mixed building naming schemes.',
+      ]}
+      example={
+        <div className="flex flex-wrap items-center justify-center gap-4">
+          <FloorBadge floor={1} />
+          <FloorBadge floor={2} className="from-emerald-500 to-teal-500" />
+          <FloorBadge floor="Roof" className="from-violet-500 to-fuchsia-500" />
+        </div>
+      }
+      installName="floor-badge"
+      sourcePaths={[
+        'libs/shadcnui-signage/src/lib/primitives/FloorBadge.tsx',
+        'libs/shadcnui-signage/src/lib/utils/cn.ts',
+      ]}
+      dependencyInstall="pnpm add clsx tailwind-merge"
+      usageFilename="DirectoryLegend.tsx"
+      usageCode={`import { FloorBadge } from '@/components/signage/primitives/FloorBadge';
+
+export function DirectoryLegend() {
+  return <FloorBadge floor={4} />;
+}`}
+      signageNotes={[
+        {
+          title: 'Fast Recognition',
+          body: 'Use FloorBadge when the floor label needs to be understood at a glance without reading supporting copy.',
+        },
+        {
+          title: 'Small Surface Area',
+          body: 'The badge is designed to slot into cards, map legends, and wayfinding headers without dominating the layout.',
+        },
+        {
+          title: 'Consistent Labeling',
+          body: 'Because the component always renders the “Floor” prefix, it helps standardize wayfinding language across screens.',
+        },
+      ]}
+      links={[
+        {
+          label: 'View Source',
+          href: 'https://github.com/CambridgeMonorail/WallRun/blob/main/libs/shadcnui-signage/src/lib/primitives/FloorBadge.tsx',
+        },
+        {
+          label: 'Library README',
+          href: 'https://github.com/CambridgeMonorail/WallRun/blob/main/libs/shadcnui-signage/README.md',
+        },
+      ]}
+    />
+  );
+};

--- a/apps/client/src/app/pages/components/primitives/InfoListDoc.tsx
+++ b/apps/client/src/app/pages/components/primitives/InfoListDoc.tsx
@@ -1,0 +1,73 @@
+import { FC } from 'react';
+import { ComponentDocTemplate } from '../../../components/ComponentDocTemplate';
+import { InfoList } from '@wallrun/shadcnui-signage';
+
+export const InfoListDocPage: FC = () => {
+  return (
+    <ComponentDocTemplate
+      category="Primitives"
+      name="InfoList"
+      description="Large-format bullet list for lobby messages, instructions, and operational notes."
+      builtOnSummary="Native unordered list with shared cn utility and signage-sized list styling."
+      builtOnPoints={[
+        'Displays operational notes as a clean stacked list with generous spacing.',
+        'Keeps body copy large enough for queueing areas, lobbies, and service counters.',
+        'Works inside panels, sidebars, and secondary message zones.',
+      ]}
+      example={
+        <div className="mx-auto max-w-4xl text-white">
+          <InfoList
+            items={[
+              'Check in at reception on arrival.',
+              'Guest Wi-Fi details are available from the host desk.',
+              'Workshop rooms open ten minutes before each session.',
+            ]}
+          />
+        </div>
+      }
+      installName="info-list"
+      sourcePaths={[
+        'libs/shadcnui-signage/src/lib/primitives/InfoList.tsx',
+        'libs/shadcnui-signage/src/lib/utils/cn.ts',
+      ]}
+      dependencyInstall="pnpm add clsx tailwind-merge"
+      usageFilename="VisitorInfo.tsx"
+      usageCode={`import { InfoList } from '@/components/signage/primitives/InfoList';
+
+export function VisitorInfo() {
+  return (
+    <InfoList
+      items={[
+        'Badge collection closes at 17:00.',
+        'Use the east entrance after 18:00.',
+      ]}
+    />
+  );
+}`}
+      signageNotes={[
+        {
+          title: 'Bullet-Led Messaging',
+          body: 'Use InfoList for concise operational instructions rather than long paragraphs that are harder to scan at distance.',
+        },
+        {
+          title: 'Panel Companion',
+          body: 'The component pairs well with SignagePanel when you need framed supporting notes alongside a primary hero or schedule.',
+        },
+        {
+          title: 'Consistent Rhythm',
+          body: 'Keep list items short and parallel so the spacing and typographic rhythm do most of the legibility work.',
+        },
+      ]}
+      links={[
+        {
+          label: 'View Source',
+          href: 'https://github.com/CambridgeMonorail/WallRun/blob/main/libs/shadcnui-signage/src/lib/primitives/InfoList.tsx',
+        },
+        {
+          label: 'Library README',
+          href: 'https://github.com/CambridgeMonorail/WallRun/blob/main/libs/shadcnui-signage/README.md',
+        },
+      ]}
+    />
+  );
+};

--- a/apps/client/src/app/pages/components/primitives/LocationIndicatorDoc.tsx
+++ b/apps/client/src/app/pages/components/primitives/LocationIndicatorDoc.tsx
@@ -1,0 +1,62 @@
+import { FC } from 'react';
+import { ComponentDocTemplate } from '../../../components/ComponentDocTemplate';
+import { LocationIndicator } from '@wallrun/shadcnui-signage';
+
+export const LocationIndicatorDocPage: FC = () => {
+  return (
+    <ComponentDocTemplate
+      category="Primitives"
+      name="LocationIndicator"
+      description="Current-location chip with map pin iconography for directory and wayfinding screens."
+      builtOnSummary="Native signage pill with Lucide iconography and shared utility styling."
+      builtOnPoints={[
+        'Uses MapPin from Lucide to reinforce place and orientation cues.',
+        'Combines a configurable label with the active location value.',
+        'Fits naturally into headers, map callouts, and directory landing states.',
+      ]}
+      example={
+        <div className="flex justify-center">
+          <LocationIndicator label="Current zone:" location="North Atrium" />
+        </div>
+      }
+      installName="location-indicator"
+      sourcePaths={[
+        'libs/shadcnui-signage/src/lib/primitives/LocationIndicator.tsx',
+        'libs/shadcnui-signage/src/lib/utils/cn.ts',
+      ]}
+      dependencyInstall="pnpm add clsx lucide-react tailwind-merge"
+      usageFilename="LobbyHeader.tsx"
+      usageCode={`import { LocationIndicator } from '@/components/signage/primitives/LocationIndicator';
+
+export function LobbyHeader() {
+  return (
+    <LocationIndicator label="You are here:" location="Visitor Reception" />
+  );
+}`}
+      signageNotes={[
+        {
+          title: 'Orientation Cue',
+          body: 'Use LocationIndicator near page titles or maps so viewers always know which zone or building area they are reading.',
+        },
+        {
+          title: 'Header-Friendly',
+          body: 'Its pill layout keeps the location visible without needing a full-width header treatment.',
+        },
+        {
+          title: 'Readable Prefix',
+          body: 'The optional label helps clarify whether the location is current position, destination, or service point.',
+        },
+      ]}
+      links={[
+        {
+          label: 'View Source',
+          href: 'https://github.com/CambridgeMonorail/WallRun/blob/main/libs/shadcnui-signage/src/lib/primitives/LocationIndicator.tsx',
+        },
+        {
+          label: 'Library README',
+          href: 'https://github.com/CambridgeMonorail/WallRun/blob/main/libs/shadcnui-signage/README.md',
+        },
+      ]}
+    />
+  );
+};

--- a/apps/client/src/app/pages/components/primitives/MeetingRowDoc.tsx
+++ b/apps/client/src/app/pages/components/primitives/MeetingRowDoc.tsx
@@ -1,0 +1,60 @@
+import { FC } from 'react';
+import { ComponentDocTemplate } from '../../../components/ComponentDocTemplate';
+import { MeetingRow } from '@wallrun/shadcnui-signage';
+
+export const MeetingRowDocPage: FC = () => {
+  return (
+    <ComponentDocTemplate
+      category="Primitives"
+      name="MeetingRow"
+      description="Agenda-style row for meeting schedules, room bookings, and office lobby loop content."
+      builtOnSummary="Native schedule row with shared cn utility and tabular alignment."
+      builtOnPoints={[
+        'Uses tabular numerals for time and room labels so schedule columns stay stable.',
+        'Switches from stacked to horizontal layout across breakpoints for large-format readability.',
+        'Designed to be repeated inside schedules and panel-based meeting lists.',
+      ]}
+      example={
+        <div className="mx-auto max-w-4xl text-white">
+          <MeetingRow time="09:30" title="Design Review" room="Studio A" />
+        </div>
+      }
+      installName="meeting-row"
+      sourcePaths={[
+        'libs/shadcnui-signage/src/lib/primitives/MeetingRow.tsx',
+        'libs/shadcnui-signage/src/lib/utils/cn.ts',
+      ]}
+      dependencyInstall="pnpm add clsx tailwind-merge"
+      usageFilename="RoomSchedule.tsx"
+      usageCode={`import { MeetingRow } from '@/components/signage/primitives/MeetingRow';
+
+export function RoomSchedule() {
+  return <MeetingRow time="14:15" title="Partner Update" room="North 2" />;
+}`}
+      signageNotes={[
+        {
+          title: 'Schedule Legibility',
+          body: 'MeetingRow emphasizes time first, then title, then room so viewers can scan fast-moving lobby schedules efficiently.',
+        },
+        {
+          title: 'Repeatable Pattern',
+          body: 'Use multiple rows inside a panel or timetable zone rather than treating the component as a standalone callout.',
+        },
+        {
+          title: 'Stable Numerals',
+          body: 'Tabular numerals help time and room data stay aligned even when entries refresh throughout the day.',
+        },
+      ]}
+      links={[
+        {
+          label: 'View Source',
+          href: 'https://github.com/CambridgeMonorail/WallRun/blob/main/libs/shadcnui-signage/src/lib/primitives/MeetingRow.tsx',
+        },
+        {
+          label: 'Library README',
+          href: 'https://github.com/CambridgeMonorail/WallRun/blob/main/libs/shadcnui-signage/README.md',
+        },
+      ]}
+    />
+  );
+};

--- a/apps/client/src/app/pages/components/primitives/MenuItemDoc.tsx
+++ b/apps/client/src/app/pages/components/primitives/MenuItemDoc.tsx
@@ -1,0 +1,70 @@
+import { FC } from 'react';
+import { ComponentDocTemplate } from '../../../components/ComponentDocTemplate';
+import { MenuItem } from '@wallrun/shadcnui-signage';
+
+export const MenuItemDocPage: FC = () => {
+  return (
+    <ComponentDocTemplate
+      category="Primitives"
+      name="MenuItem"
+      description="Price-led menu row with optional description and divider treatment for large-format menu boards."
+      builtOnSummary="Custom menu row with shared cn utility and signage-sized typography."
+      builtOnPoints={[
+        'Keeps item name and price visually coupled across responsive breakpoints.',
+        'Supports optional description text without forcing a denser layout.',
+        'Uses an optional divider to preserve rhythm in stacked menu lists.',
+      ]}
+      example={
+        <div className="mx-auto max-w-3xl">
+          <MenuItem
+            name="Roasted Mushroom Flatbread"
+            price="$14"
+            description="Mozzarella, rosemary oil, and caramelised onion"
+          />
+        </div>
+      }
+      installName="menu-item"
+      sourcePaths={[
+        'libs/shadcnui-signage/src/lib/primitives/MenuItem.tsx',
+        'libs/shadcnui-signage/src/lib/utils/cn.ts',
+      ]}
+      dependencyInstall="pnpm add clsx tailwind-merge"
+      usageFilename="LunchMenu.tsx"
+      usageCode={`import { MenuItem } from '@/components/signage/primitives/MenuItem';
+
+export function LunchMenu() {
+  return (
+    <MenuItem
+      name="Citrus Chicken Bowl"
+      price="$16"
+      description="Herb rice, charred broccoli, and tahini drizzle"
+    />
+  );
+}`}
+      signageNotes={[
+        {
+          title: 'Price Hierarchy',
+          body: 'The component is tuned so the price reads quickly without visually overpowering the dish name.',
+        },
+        {
+          title: 'Description Density',
+          body: 'Reserve descriptions for items that genuinely need supporting detail; the component works cleanly with or without them.',
+        },
+        {
+          title: 'Stacked Menus',
+          body: 'Use the divider for long menu lists and disable it on the final row when the surrounding layout already provides separation.',
+        },
+      ]}
+      links={[
+        {
+          label: 'View Source',
+          href: 'https://github.com/CambridgeMonorail/WallRun/blob/main/libs/shadcnui-signage/src/lib/primitives/MenuItem.tsx',
+        },
+        {
+          label: 'Library README',
+          href: 'https://github.com/CambridgeMonorail/WallRun/blob/main/libs/shadcnui-signage/README.md',
+        },
+      ]}
+    />
+  );
+};

--- a/apps/client/src/app/pages/components/primitives/MenuSectionDoc.tsx
+++ b/apps/client/src/app/pages/components/primitives/MenuSectionDoc.tsx
@@ -35,7 +35,8 @@ export const MenuSectionDocPage: FC = () => {
       ]}
       dependencyInstall="pnpm add clsx tailwind-merge"
       usageFilename="CafeBoard.tsx"
-      usageCode={`import { MenuItem, MenuSection } from '@/components/signage/primitives';
+      usageCode={`import { MenuItem } from '@/components/signage/primitives/MenuItem';
+    import { MenuSection } from '@/components/signage/primitives/MenuSection';
 
 export function CafeBoard() {
   return (

--- a/apps/client/src/app/pages/components/primitives/MenuSectionDoc.tsx
+++ b/apps/client/src/app/pages/components/primitives/MenuSectionDoc.tsx
@@ -1,0 +1,74 @@
+import { FC } from 'react';
+import { ComponentDocTemplate } from '../../../components/ComponentDocTemplate';
+import { MenuItem, MenuSection } from '@wallrun/shadcnui-signage';
+
+export const MenuSectionDocPage: FC = () => {
+  return (
+    <ComponentDocTemplate
+      category="Primitives"
+      name="MenuSection"
+      description="Section wrapper for grouped menu content with headline and accent divider."
+      builtOnSummary="Native section shell with shared cn utility and composable child content."
+      builtOnPoints={[
+        'Provides a consistent menu heading, accent bar, and content wrapper.',
+        'Works with MenuItem or any custom child layout that needs grouped presentation.',
+        'Keeps category structure explicit for breakfast, lunch, specials, or service groupings.',
+      ]}
+      example={
+        <div className="mx-auto max-w-4xl">
+          <MenuSection title="Breakfast" contentClassName="space-y-5">
+            <MenuItem name="Smoked Salmon Roll" price="$11" />
+            <MenuItem
+              name="Chilli Eggs"
+              price="$9"
+              description="Toasted sourdough and herb butter"
+              hideDivider={true}
+            />
+          </MenuSection>
+        </div>
+      }
+      installName="menu-section"
+      sourcePaths={[
+        'libs/shadcnui-signage/src/lib/primitives/MenuSection.tsx',
+        'libs/shadcnui-signage/src/lib/primitives/MenuItem.tsx',
+        'libs/shadcnui-signage/src/lib/utils/cn.ts',
+      ]}
+      dependencyInstall="pnpm add clsx tailwind-merge"
+      usageFilename="CafeBoard.tsx"
+      usageCode={`import { MenuItem, MenuSection } from '@/components/signage/primitives';
+
+export function CafeBoard() {
+  return (
+    <MenuSection title="Pastries" contentClassName="space-y-4">
+      <MenuItem name="Almond Croissant" price="$5" />
+      <MenuItem name="Seasonal Tart" price="$6" hideDivider={true} />
+    </MenuSection>
+  );
+}`}
+      signageNotes={[
+        {
+          title: 'Section Rhythm',
+          body: 'Use MenuSection to break a large board into obvious content zones that can be read from a distance.',
+        },
+        {
+          title: 'Accent Control',
+          body: 'The accent bar lets you reinforce brand color or daypart shifts without rebuilding the heading treatment.',
+        },
+        {
+          title: 'Composable Content',
+          body: 'Because the body accepts arbitrary children, the section can mix menu rows, disclaimers, and small promotional notes.',
+        },
+      ]}
+      links={[
+        {
+          label: 'View Source',
+          href: 'https://github.com/CambridgeMonorail/WallRun/blob/main/libs/shadcnui-signage/src/lib/primitives/MenuSection.tsx',
+        },
+        {
+          label: 'Library README',
+          href: 'https://github.com/CambridgeMonorail/WallRun/blob/main/libs/shadcnui-signage/README.md',
+        },
+      ]}
+    />
+  );
+};

--- a/apps/client/src/app/pages/components/primitives/SignagePanelDoc.tsx
+++ b/apps/client/src/app/pages/components/primitives/SignagePanelDoc.tsx
@@ -1,0 +1,71 @@
+import { FC } from 'react';
+import { ComponentDocTemplate } from '../../../components/ComponentDocTemplate';
+import { InfoList, SignagePanel } from '@wallrun/shadcnui-signage';
+
+export const SignagePanelDocPage: FC = () => {
+  return (
+    <ComponentDocTemplate
+      category="Primitives"
+      name="SignagePanel"
+      description="Bordered content panel for grouped operational or supporting information on signage screens."
+      builtOnSummary="Glass-like content panel built with shared cn utility and optional panel labeling."
+      builtOnPoints={[
+        'Creates a restrained bordered container for secondary or supporting content.',
+        'Supports an optional label line above the main panel body.',
+        'Works well with child content such as InfoList, MeetingRow, or custom markup.',
+      ]}
+      example={
+        <div className="mx-auto max-w-4xl text-white">
+          <SignagePanel label="Visitor Notes">
+            <InfoList
+              items={[
+                'Check in at reception before entering the studio floor.',
+                'Use the blue lift bank for rooms 3.01 to 3.18.',
+              ]}
+            />
+          </SignagePanel>
+        </div>
+      }
+      installName="signage-panel"
+      sourcePaths={[
+        'libs/shadcnui-signage/src/lib/primitives/SignagePanel.tsx',
+        'libs/shadcnui-signage/src/lib/utils/cn.ts',
+      ]}
+      dependencyInstall="pnpm add clsx tailwind-merge"
+      usageFilename="LobbyNotes.tsx"
+      usageCode={`import { SignagePanel } from '@/components/signage/primitives/SignagePanel';
+
+export function LobbyNotes() {
+  return (
+    <SignagePanel label="Today">
+      <p className="text-2xl text-white/80">Reception closes at 18:30.</p>
+    </SignagePanel>
+  );
+}`}
+      signageNotes={[
+        {
+          title: 'Secondary Information',
+          body: 'Use SignagePanel for grouped notes, schedules, or status items that should feel contained but still readable from distance.',
+        },
+        {
+          title: 'Content Flexibility',
+          body: 'The component is intentionally lightweight so it can host lists, rows, or richer custom content without dictating the inner layout.',
+        },
+        {
+          title: 'Quiet Framing',
+          body: 'Its subtle border and translucent background help supporting content stay visually subordinate to the main headline area.',
+        },
+      ]}
+      links={[
+        {
+          label: 'View Source',
+          href: 'https://github.com/CambridgeMonorail/WallRun/blob/main/libs/shadcnui-signage/src/lib/primitives/SignagePanel.tsx',
+        },
+        {
+          label: 'Library README',
+          href: 'https://github.com/CambridgeMonorail/WallRun/blob/main/libs/shadcnui-signage/README.md',
+        },
+      ]}
+    />
+  );
+};

--- a/docs/plans/2026-05-03-component-docs-parity.md
+++ b/docs/plans/2026-05-03-component-docs-parity.md
@@ -1,0 +1,34 @@
+# Client Component Docs Parity Plan
+
+## Goal
+
+Bring the client component docs surface into parity with the current `@wallrun/shadcnui-signage` export surface.
+
+## Initial Hypothesis
+
+The parity gap exists because newer signage exports were added to the library and Storybook, but the client docs only updated the older component index and route inventory.
+
+- the missing components are exported from `libs/shadcnui-signage/src/index.ts`
+- the client component index still lists the older inventory
+- no client doc pages currently exist for the newer exported components
+
+## Cheap Discriminating Checks
+
+- confirm whether missing components already have client `*Doc.tsx` pages
+- confirm whether `navigationConfig.ts` already includes paths and routes for those components
+- confirm whether the exported library inventory still contains the missing components from issue `#72`
+
+## Scope
+
+- add client doc pages for the newer exported signage components
+- add the missing routes and sidebar entries for those docs pages
+- update the component index so the public client docs match the intended inventory
+
+## Validation
+
+- run editor/language-service validation on the touched client files
+- run a narrow client validation command if the terminal returns usable output
+
+## Expected Result
+
+The client docs site, sidebar, and component index present the same component inventory that the library currently exports, eliminating the mismatch described in issue `#72`.


### PR DESCRIPTION
## Summary

Closes #72.

This brings the client component docs surface into parity with the current `@wallrun/shadcnui-signage` export inventory.

## What Changed

- added client docs pages for:
  - `DirectoryCard`
  - `FloorBadge`
  - `LocationIndicator`
  - `MenuItem`
  - `MenuSection`
  - `SignagePanel`
  - `MeetingRow`
  - `InfoList`
  - `MenuBoard`
- added a shared `ComponentDocTemplate` to keep the new pages consistent
- updated the client component index to include the newer exported components
- added the missing component routes and sidebar entries in `navigationConfig.ts`
- added the required plan note for the work

## Why

The library export surface and Storybook had moved ahead of the client docs surface. The client site still presented the older component inventory, which meant the public docs and the actual exported API were giving conflicting signals.

This change makes the client docs, sidebar, and component index line up with the exported signage components currently available from `@wallrun/shadcnui-signage`.

## Validation

- editor/language-service validation reported no errors on the touched files
- ran a narrow client typecheck successfully:

```bash
pnpm exec tsc --project apps/client/tsconfig.app.json --noEmit
```

## Notes

This slice focuses on docs parity and route/index coverage. It does not change the underlying signage component implementations.
