### PR TITLE
feat(shadcnui-signage): add CTABanner primitive

### DIFF
--- a/apps/client/src/app/components/CodeSnippet.test.tsx
+++ b/apps/client/src/app/components/CodeSnippet.test.tsx
@@ -2,6 +2,10 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
 import { CodeSnippet } from './CodeSnippet';
+import {
+  LEGACY_REGISTRY_URL,
+  PUBLIC_REGISTRY_URL,
+} from './componentDocs.constants';
 
 describe('CodeSnippet', () => {
   const sampleCode = `import { Button } from '@wallrun/shadcnui';
@@ -35,6 +39,29 @@ export const App = () => <Button>Click me</Button>;`;
 
     await waitFor(() => {
       expect(navigator.clipboard.writeText).toHaveBeenCalledWith(sampleCode);
+    });
+  });
+
+  it('rewrites legacy registry URLs in rendered code output', () => {
+    const legacyRegistryCode = `npx shadcn@latest add ${LEGACY_REGISTRY_URL} menu-board`;
+
+    render(<CodeSnippet code={legacyRegistryCode} language="bash" />);
+
+    expect(screen.getByText(`npx shadcn@latest add ${PUBLIC_REGISTRY_URL} menu-board`)).toBeInTheDocument();
+    expect(screen.queryByText(legacyRegistryCode)).not.toBeInTheDocument();
+  });
+
+  it('copies rewritten registry URLs to the clipboard', async () => {
+    const legacyRegistryCode = `npx shadcn@latest add ${LEGACY_REGISTRY_URL} menu-board`;
+
+    render(<CodeSnippet code={legacyRegistryCode} language="bash" />);
+
+    fireEvent.click(screen.getByTestId('copy-button'));
+
+    await waitFor(() => {
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+        `npx shadcn@latest add ${PUBLIC_REGISTRY_URL} menu-board`,
+      );
     });
   });
 

--- a/apps/client/src/app/components/CodeSnippet.tsx
+++ b/apps/client/src/app/components/CodeSnippet.tsx
@@ -58,7 +58,7 @@ export const CodeSnippet: FC<CodeSnippetProps> = ({
   'data-testid': dataTestId = 'code-snippet',
 }) => {
   const [copied, setCopied] = useState(false);
-  const displayedCode = code.replaceAll(LEGACY_REGISTRY_URL, PUBLIC_REGISTRY_URL);
+  const displayedCode = code.split(LEGACY_REGISTRY_URL).join(PUBLIC_REGISTRY_URL);
 
   const handleCopy = async () => {
     try {
@@ -115,7 +115,7 @@ export const CodeSnippet: FC<CodeSnippetProps> = ({
         >
           {showLineNumbers ? (
             <code className="relative">
-              {lines.map((line, index) => (
+              {lines.map((line: string, index: number) => (
                 <div key={index} className="table-row">
                   <span className="table-cell text-right pr-4 text-muted-foreground select-none w-8">
                     {index + 1}

--- a/apps/client/src/app/pages/signage/EventSchedule.tsx
+++ b/apps/client/src/app/pages/signage/EventSchedule.tsx
@@ -1,6 +1,8 @@
 import { FC } from 'react';
+import { Smartphone } from 'lucide-react';
 import { SignageExample } from './components/SignageExample';
 import {
+  CTABanner,
   SignageContainer,
   SignageHeader,
   EventCard,
@@ -109,12 +111,11 @@ export const EventSchedule: FC = () => {
         </div>
 
         <footer className="mt-10 text-center sm:mt-12 lg:mt-16">
-          <div className="inline-block rounded-2xl border border-slate-700/60 bg-slate-900/70 px-5 py-4 backdrop-blur-sm sm:px-8 sm:py-5 lg:px-12 lg:py-6">
-            <p className="text-base text-slate-100 sm:text-lg lg:text-2xl">
-              Download the mobile app for personalized schedule and
-              notifications
-            </p>
-          </div>
+          <CTABanner
+            message="Download the mobile app for personalized schedule and notifications"
+            icon={Smartphone}
+            action={{ label: 'Open app', href: '#mobile-app' }}
+          />
         </footer>
       </SignageContainer>
     </SignageExample>

--- a/apps/client/src/app/pages/signage/EventSchedule.tsx
+++ b/apps/client/src/app/pages/signage/EventSchedule.tsx
@@ -114,7 +114,6 @@ export const EventSchedule: FC = () => {
           <CTABanner
             message="Download the mobile app for personalized schedule and notifications"
             icon={Smartphone}
-            action={{ label: 'Open app', href: '#mobile-app' }}
           />
         </footer>
       </SignageContainer>

--- a/apps/client/src/app/pages/signage/KPIDashboard.tsx
+++ b/apps/client/src/app/pages/signage/KPIDashboard.tsx
@@ -1,7 +1,14 @@
 import { FC } from 'react';
 import { SignageExample } from './components/SignageExample';
-import { TrendingUp, Users, DollarSign, ShoppingCart } from 'lucide-react';
 import {
+  TrendingUp,
+  Users,
+  DollarSign,
+  ShoppingCart,
+  LayoutDashboard,
+} from 'lucide-react';
+import {
+  CTABanner,
   SignageContainer,
   SignageHeader,
   MetricCard,
@@ -53,11 +60,10 @@ export const KPIDashboard: FC = () => {
         </div>
 
         <footer className="mt-10 text-center sm:mt-12 lg:mt-16">
-          <div className="inline-block rounded-2xl border border-slate-700/50 bg-gradient-to-r from-slate-800/50 via-slate-700/50 to-slate-800/50 px-5 py-4 backdrop-blur-sm sm:px-8 sm:py-5 lg:px-12 lg:py-6">
-            <p className="text-base text-slate-400 sm:text-lg lg:text-xl">
-              Dashboard powered by WallRun • Digital signage toolkit
-            </p>
-          </div>
+          <CTABanner
+            message="Dashboard powered by WallRun • Digital signage toolkit"
+            icon={LayoutDashboard}
+          />
         </footer>
       </SignageContainer>
     </SignageExample>

--- a/apps/client/src/app/pages/signage/OfficeDirectory.tsx
+++ b/apps/client/src/app/pages/signage/OfficeDirectory.tsx
@@ -1,5 +1,7 @@
 import { FC } from 'react';
+import { ConciergeBell } from 'lucide-react';
 import {
+  CTABanner,
   DirectoryCard,
   LocationIndicator,
   SignageContainer,
@@ -53,10 +55,12 @@ export const OfficeDirectory: FC = () => {
             ))}
           </div>
 
-          <footer className="rounded-3xl border border-blue-500/50 bg-gradient-to-r from-blue-600 via-cyan-600 to-blue-600 p-5 text-center text-white shadow-2xl sm:p-8 lg:p-10">
-            <p className="text-lg font-medium sm:text-2xl lg:text-3xl">
-              For assistance, please contact Reception at extension 1001
-            </p>
+          <footer className="text-center">
+            <CTABanner
+              message="For assistance, please contact Reception at extension 1001"
+              icon={ConciergeBell}
+              variant="accent"
+            />
           </footer>
         </div>
       </SignageContainer>

--- a/apps/client/src/app/pages/signage/RestaurantMenu.tsx
+++ b/apps/client/src/app/pages/signage/RestaurantMenu.tsx
@@ -1,5 +1,11 @@
 import { FC } from 'react';
-import { MenuBoard, MenuItem, MenuSection } from '@wallrun/shadcnui-signage';
+import { UtensilsCrossed } from 'lucide-react';
+import {
+  CTABanner,
+  MenuBoard,
+  MenuItem,
+  MenuSection,
+} from '@wallrun/shadcnui-signage';
 import { SignageExample } from './components/SignageExample';
 
 const menuCategories = {
@@ -65,10 +71,12 @@ export const RestaurantMenu: FC = () => {
         subtitle="Fresh. Local. Delicious."
         data-testid="restaurant-menu"
         footer={
-          <footer className="mt-10 border-t border-slate-800 pt-6 text-center sm:mt-12 sm:pt-8 lg:mt-16">
-            <p className="text-base text-slate-400 sm:text-xl lg:text-2xl">
-              Ask your server about daily specials and dietary options
-            </p>
+          <footer className="mt-10 text-center sm:mt-12 lg:mt-16">
+            <CTABanner
+              message="Ask your server about daily specials and dietary options"
+              icon={UtensilsCrossed}
+              variant="gradient"
+            />
           </footer>
         }
       >

--- a/docs/plans/2026-05-03-cta-banner-primitive.md
+++ b/docs/plans/2026-05-03-cta-banner-primitive.md
@@ -1,0 +1,27 @@
+# Issue #53: CTABanner primitive
+
+## Goal
+
+Add a reusable signage footer callout primitive for help text, support instructions, and promotional banners.
+
+## Context
+
+- Multiple demo pages currently hand-roll large footer banners with similar spacing, typography, and glass/gradient styling.
+- The component should live in `libs/shadcnui-signage/src/lib/primitives` and be exported from the package root.
+- The issue requires Storybook coverage and unit tests.
+
+## Scope
+
+1. Add `CTABanner` primitive with variant support, optional icon, and optional action link.
+2. Add Storybook stories for the supported variants.
+3. Add unit tests covering rendering, variants, icon, and link behavior.
+4. Refactor the demo pages that currently duplicate the footer banner pattern to use the new primitive.
+
+## Validation
+
+- `pnpm test:shadcnui-signage`
+- `pnpm type-check:affected`
+
+## Expected Outcome
+
+The signage library exposes a reusable CTA banner primitive, and the demo pages consume it instead of repeated footer banner markup.

--- a/libs/shadcnui-signage/src/index.ts
+++ b/libs/shadcnui-signage/src/index.ts
@@ -30,6 +30,12 @@ export { MeetingRow } from './lib/primitives/MeetingRow';
 export type { MeetingRowProps } from './lib/primitives/MeetingRow';
 export { InfoList } from './lib/primitives/InfoList';
 export type { InfoListProps } from './lib/primitives/InfoList';
+export { CTABanner } from './lib/primitives/CTABanner';
+export type {
+  CTABannerProps,
+  CTABannerAction,
+  CTABannerVariant,
+} from './lib/primitives/CTABanner';
 
 // Layouts
 export { SplitScreen } from './lib/layouts/SplitScreen';

--- a/libs/shadcnui-signage/src/lib/primitives/CTABanner.spec.tsx
+++ b/libs/shadcnui-signage/src/lib/primitives/CTABanner.spec.tsx
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Smartphone } from 'lucide-react';
+import { CTABanner } from './CTABanner';
+
+describe('CTABanner', () => {
+  it('renders the message text', () => {
+    render(<CTABanner message="Download the mobile app" />);
+
+    expect(screen.getByText('Download the mobile app')).toBeInTheDocument();
+  });
+
+  it('renders an icon when provided', () => {
+    const { container } = render(
+      <CTABanner message="Get event updates" icon={Smartphone} />,
+    );
+
+    expect(container.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('renders the action link when provided', () => {
+    render(
+      <CTABanner
+        message="Open the support site"
+        action={{ label: 'Support', href: 'https://wallrun.dev/support' }}
+      />,
+    );
+
+    expect(screen.getByRole('link', { name: 'Support' })).toHaveAttribute(
+      'href',
+      'https://wallrun.dev/support',
+    );
+  });
+
+  it('applies the requested variant through a stable data attribute', () => {
+    render(<CTABanner message="Priority updates" variant="gradient" />);
+
+    expect(screen.getByTestId('cta-banner')).toHaveAttribute(
+      'data-variant',
+      'gradient',
+    );
+  });
+
+  it('keeps distance-readable text sizing classes on the message', () => {
+    render(<CTABanner message="Reception assistance available" />);
+
+    expect(screen.getByText('Reception assistance available')).toHaveClass(
+      'text-base',
+      'sm:text-lg',
+      'lg:text-2xl',
+    );
+  });
+});

--- a/libs/shadcnui-signage/src/lib/primitives/CTABanner.stories.tsx
+++ b/libs/shadcnui-signage/src/lib/primitives/CTABanner.stories.tsx
@@ -1,0 +1,61 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Smartphone, Tickets, UtensilsCrossed } from 'lucide-react';
+import { ScreenFrame } from './ScreenFrame';
+import { CTABanner } from './CTABanner';
+
+const meta: Meta<typeof CTABanner> = {
+  title: 'Signage/Primitives/CTABanner',
+  component: CTABanner,
+  tags: ['autodocs'],
+  argTypes: {
+    message: {
+      control: 'text',
+    },
+    variant: {
+      control: 'select',
+      options: ['default', 'accent', 'gradient'],
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="bg-slate-950/95 p-8">
+        <ScreenFrame resolution="1080p" scale={0.4}>
+          <div className="flex min-h-screen items-end justify-center bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 p-16 text-white">
+            <Story />
+          </div>
+        </ScreenFrame>
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof CTABanner>;
+
+export const Default: Story = {
+  args: {
+    message: 'Ask your server about daily specials and dietary options',
+    icon: UtensilsCrossed,
+    variant: 'default',
+  },
+};
+
+export const Accent: Story = {
+  args: {
+    message: 'For assistance, please contact Reception at extension 1001',
+    icon: Tickets,
+    variant: 'accent',
+  },
+};
+
+export const WithAction: Story = {
+  args: {
+    message: 'Download the mobile app for personalized schedule and notifications',
+    icon: Smartphone,
+    variant: 'gradient',
+    action: {
+      label: 'Open app',
+      href: '#download-app',
+    },
+  },
+};

--- a/libs/shadcnui-signage/src/lib/primitives/CTABanner.stories.tsx
+++ b/libs/shadcnui-signage/src/lib/primitives/CTABanner.stories.tsx
@@ -58,4 +58,16 @@ export const WithAction: Story = {
       href: '#download-app',
     },
   },
+  render: (args) => (
+    <div className="flex w-full flex-col items-center justify-end gap-6">
+      <CTABanner {...args} />
+      <section
+        id="download-app"
+        aria-label="Mobile app download information"
+        className="w-full max-w-3xl rounded-md border border-white/10 bg-black/20 p-4 text-sm text-white/80"
+      >
+        Mobile app destination
+      </section>
+    </div>
+  ),
 };

--- a/libs/shadcnui-signage/src/lib/primitives/CTABanner.tsx
+++ b/libs/shadcnui-signage/src/lib/primitives/CTABanner.tsx
@@ -1,0 +1,92 @@
+import { FC } from 'react';
+import type { LucideIcon } from 'lucide-react';
+import { cn } from '../utils/cn';
+
+export type CTABannerVariant = 'default' | 'accent' | 'gradient';
+
+export interface CTABannerAction {
+  /**
+   * Action label shown as a link inside the banner
+   */
+  label: string;
+  /**
+   * Link target for the action
+   */
+  href: string;
+}
+
+export interface CTABannerProps {
+  /**
+   * Main callout message
+   */
+  message: string;
+  /**
+   * Optional leading icon for the banner message
+   */
+  icon?: LucideIcon;
+  /**
+   * Visual style variant
+   */
+  variant?: CTABannerVariant;
+  /**
+   * Optional link action displayed after the message
+   */
+  action?: CTABannerAction;
+  /**
+   * Additional CSS classes
+   */
+  className?: string;
+}
+
+const variantClasses: Record<CTABannerVariant, string> = {
+  default:
+    'border border-slate-700/60 bg-slate-900/70 text-slate-100 backdrop-blur-sm',
+  accent:
+    'border border-blue-400/40 bg-gradient-to-r from-blue-600/85 via-cyan-600/80 to-blue-600/85 text-white shadow-2xl shadow-cyan-950/30',
+  gradient:
+    'border border-fuchsia-300/30 bg-gradient-to-r from-violet-600/85 via-fuchsia-600/80 to-pink-600/85 text-white shadow-2xl shadow-fuchsia-950/30',
+};
+
+/**
+ * Distance-readable footer callout banner for signage support and promo messages.
+ */
+export const CTABanner: FC<CTABannerProps> = ({
+  message,
+  icon: Icon,
+  variant = 'default',
+  action,
+  className,
+}) => {
+  return (
+    <div
+      className={cn(
+        'inline-flex w-full max-w-5xl flex-col items-center justify-center gap-3 rounded-3xl px-5 py-4 text-center sm:px-8 sm:py-5 lg:px-12 lg:py-6',
+        variantClasses[variant],
+        className,
+      )}
+      data-testid="cta-banner"
+      data-variant={variant}
+    >
+      <div className="flex flex-col items-center justify-center gap-3 sm:flex-row sm:gap-4">
+        {Icon ? (
+          <Icon
+            aria-hidden="true"
+            className="h-6 w-6 shrink-0 sm:h-7 sm:w-7 lg:h-8 lg:w-8"
+          />
+        ) : null}
+        <p className="text-base font-medium leading-snug tracking-[0.01em] sm:text-lg lg:text-2xl">
+          {message}
+        </p>
+      </div>
+
+      {action ? (
+        <a
+          href={action.href}
+          className="rounded-full border border-white/20 bg-white/10 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-white/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/80 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent sm:text-base"
+        >
+          {action.label}
+        </a>
+      ) : null}
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary

Add a reusable `CTABanner` primitive to `@wallrun/shadcnui-signage` for footer help text, support callouts, and promotional messages.

This PR:
- adds the new `CTABanner` primitive with `default`, `accent`, and `gradient` variants
- supports optional leading Lucide icons and an optional action link
- exports the primitive from the signage package root
- adds Storybook coverage and unit tests
- refactors signage demo pages to use the shared banner instead of repeated footer markup
- fixes `CodeSnippet` client TypeScript compatibility by replacing `replaceAll` with a target-compatible fallback and adding explicit callback types

## Files / areas changed

- `libs/shadcnui-signage/src/lib/primitives/CTABanner.tsx`
- `libs/shadcnui-signage/src/lib/primitives/CTABanner.stories.tsx`
- `libs/shadcnui-signage/src/lib/primitives/CTABanner.spec.tsx`
- `libs/shadcnui-signage/src/index.ts`
- `apps/client/src/app/pages/signage/EventSchedule.tsx`
- `apps/client/src/app/pages/signage/KPIDashboard.tsx`
- `apps/client/src/app/pages/signage/OfficeDirectory.tsx`
- `apps/client/src/app/pages/signage/RestaurantMenu.tsx`
- `apps/client/src/app/components/CodeSnippet.tsx`
- `docs/plans/2026-05-03-cta-banner-primitive.md`

## Validation

```bash
pnpm test:shadcnui-signage
pnpm exec tsc --project libs/shadcnui-signage/tsconfig.lib.json --noEmit
pnpm exec tsc --project apps/client/tsconfig.app.json --noEmit
```

## Notes

The `CodeSnippet` fix is included as a separate commit on this branch because it was blocking client type-check validation during this work.
