### PR TITLE
feat(client): add tutorials section and restaurant signage guide

### DIFF
--- a/apps/client/src/app/constants/navigationConfig.ts
+++ b/apps/client/src/app/constants/navigationConfig.ts
@@ -8,6 +8,7 @@ import {
   Blocks,
   Wrench,
   BookOpen,
+  GraduationCap,
 } from 'lucide-react';
 
 import { LandingPage } from '../pages/landing/Landing';
@@ -51,6 +52,8 @@ import { CustomAgentsPage } from '../pages/how-to/CustomAgents';
 import { DesignBriefPage } from '../pages/how-to/DesignBrief';
 import { BuildSignagePage } from '../pages/how-to/BuildSignage';
 import { DeployBrightSignPage } from '../pages/how-to/DeployBrightSign';
+import { TutorialsPage } from '../pages/tutorials/Tutorials';
+import { RestaurantDigitalSignageTutorialPage } from '../pages/tutorials/RestaurantDigitalSignage';
 import { ScheduleGateDocPage } from '../pages/components/behaviour/ScheduleGateDoc';
 import { AutoPagingListDocPage } from '../pages/components/behaviour/AutoPagingListDoc';
 import { SignageTransitionDocPage } from '../pages/components/behaviour/SignageTransitionDoc';
@@ -76,6 +79,10 @@ const paths = {
     designBrief: '/how-to/design-brief',
     buildSignage: '/how-to/build-signage',
     deployBrightSign: '/how-to/deploy-brightsign',
+  },
+  tutorials: {
+    index: '/tutorials',
+    restaurantDigitalSignage: '/tutorials/restaurant-digital-signage',
   },
   signage: {
     welcome: '/signage/welcome',
@@ -176,12 +183,21 @@ const sidebarData: SidebarConfiguration = {
       ],
     },
     {
+      title: 'Tutorials',
+      url: paths.tutorials.index,
+      icon: GraduationCap,
+      items: [
+        {
+          title: 'Restaurant Digital Signage',
+          url: paths.tutorials.restaurantDigitalSignage,
+        },
+      ],
+    },
+    {
       title: 'Player Workflows',
       url: paths.tooling,
       icon: Wrench,
-      items: [
-        { title: 'Tooling & Deployment', url: paths.tooling },
-      ],
+      items: [{ title: 'Tooling & Deployment', url: paths.tooling }],
     },
     {
       title: 'Components',
@@ -196,7 +212,10 @@ const sidebarData: SidebarConfiguration = {
           title: 'AnnouncementCard',
           url: paths.components.primitives.announcementCard,
         },
-        { title: 'DirectoryCard', url: paths.components.primitives.directoryCard },
+        {
+          title: 'DirectoryCard',
+          url: paths.components.primitives.directoryCard,
+        },
         { title: 'FloorBadge', url: paths.components.primitives.floorBadge },
         {
           title: 'LocationIndicator',
@@ -303,6 +322,11 @@ const routes = [
   createRoute(paths.howTo.designBrief, DesignBriefPage),
   createRoute(paths.howTo.buildSignage, BuildSignagePage),
   createRoute(paths.howTo.deployBrightSign, DeployBrightSignPage),
+  createRoute(paths.tutorials.index, TutorialsPage),
+  createRoute(
+    paths.tutorials.restaurantDigitalSignage,
+    RestaurantDigitalSignageTutorialPage,
+  ),
   createRoute(paths.signage.welcome, WelcomeScreen, false),
   createRoute(paths.signage.menu, RestaurantMenu, false),
   createRoute(paths.signage.wayfinding, OfficeDirectory, false),

--- a/apps/client/src/app/pages/tutorials/RestaurantDigitalSignage.test.tsx
+++ b/apps/client/src/app/pages/tutorials/RestaurantDigitalSignage.test.tsx
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { BrowserRouter } from 'react-router-dom';
+import { RestaurantDigitalSignageTutorialPage } from './RestaurantDigitalSignage';
+
+describe('RestaurantDigitalSignageTutorialPage', () => {
+  const renderWithRouter = () => {
+    return render(
+      <BrowserRouter>
+        <RestaurantDigitalSignageTutorialPage />
+      </BrowserRouter>,
+    );
+  };
+
+  it('renders the tutorial title and fictional restaurant', () => {
+    renderWithRouter();
+    expect(
+      screen.getByText('Create Restaurant Digital Signage With WallRun'),
+    ).toBeInTheDocument();
+    expect(screen.getAllByText(/the lard lounge/i).length).toBeGreaterThan(0);
+  });
+
+  it('renders the case study sections', () => {
+    renderWithRouter();
+    expect(screen.getByText('The Brief')).toBeInTheDocument();
+    expect(
+      screen.getByText('Turn the Restaurant Into a Signage System'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Model the Menu Before the Layout'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Build the First Screen')).toBeInTheDocument();
+  });
+
+  it('renders implementation snippets', () => {
+    renderWithRouter();
+    expect(screen.getByText('lardLoungeMenu.ts')).toBeInTheDocument();
+    expect(screen.getByText('LardLoungeMenuScreen.tsx')).toBeInTheDocument();
+    expect(screen.getByText(/@signage-architect/)).toBeInTheDocument();
+  });
+
+  it('links to related workflow pages', () => {
+    renderWithRouter();
+    expect(
+      screen.getByRole('link', { name: /open menuboard docs/i }),
+    ).toHaveAttribute('href', '/components/blocks/menu-board');
+    expect(
+      screen.getByRole('link', { name: /create a design brief/i }),
+    ).toHaveAttribute('href', '/how-to/design-brief');
+    expect(
+      screen.getByRole('link', { name: /review deployment tooling/i }),
+    ).toHaveAttribute('href', '/tooling');
+  });
+});

--- a/apps/client/src/app/pages/tutorials/RestaurantDigitalSignage.tsx
+++ b/apps/client/src/app/pages/tutorials/RestaurantDigitalSignage.tsx
@@ -1,0 +1,479 @@
+import { FC } from 'react';
+import { Link } from 'react-router-dom';
+import {
+  BadgeDollarSign,
+  CheckCircle,
+  ClipboardList,
+  Code,
+  LayoutTemplate,
+  Monitor,
+  Package,
+  Palette,
+  Utensils,
+} from 'lucide-react';
+import { Button } from '@wallrun/shadcnui';
+import { CodeSnippet } from '../../components/CodeSnippet';
+
+const menuDataCode = `type MenuItem = {
+  name: string;
+  description: string;
+  price: string;
+  tags?: string[];
+};
+
+type MenuCategory = {
+  title: string;
+  items: MenuItem[];
+};
+
+export const lardLoungeMenu: MenuCategory[] = [
+  {
+    title: 'Lard Classics',
+    items: [
+      {
+        name: 'Confit Lard Toast',
+        description: 'Sourdough, whipped cultured lard, pickled shallot',
+        price: '$12',
+        tags: ['signature'],
+      },
+      {
+        name: 'Golden Dripping Fries',
+        description: 'Triple-cooked potatoes, rosemary salt, lard aioli',
+        price: '$9',
+      },
+      {
+        name: 'Lardo Carbonara',
+        description: 'Rigatoni, cured lardons, black pepper, yolk',
+        price: '$24',
+      },
+    ],
+  },
+  {
+    title: 'Modern Plates',
+    items: [
+      {
+        name: 'Lard-Seared Cabbage',
+        description: 'Charred hispi, apple glaze, crisp crumb',
+        price: '$18',
+      },
+      {
+        name: 'Pork Fat Risotto',
+        description: 'Pearl barley, smoked lard, parmesan, chive',
+        price: '$22',
+      },
+    ],
+  },
+];`;
+
+const componentCode = `import {
+  MenuBoard,
+  MenuSection,
+  SignageContainer,
+  SignageHeader,
+  SignagePanel,
+} from '@wallrun/shadcnui-signage';
+import { lardLoungeMenu } from './lardLoungeMenu';
+
+export const LardLoungeMenuScreen = () => {
+  return (
+    <SignageContainer variant="neutral" showGrid={false}>
+      <SignageHeader
+        tag="Dinner"
+        title="The Lard Lounge"
+        subtitle="Modern comfort dishes built around carefully sourced lard"
+      />
+
+      <div className="mt-10 grid grid-cols-[1.4fr_0.9fr] gap-8">
+        <MenuBoard title="Tonight's Menu">
+          {lardLoungeMenu.map((category) => (
+            <MenuSection
+              key={category.title}
+              title={category.title}
+              items={category.items}
+            />
+          ))}
+        </MenuBoard>
+
+        <SignagePanel>
+          <p className="text-4xl font-semibold">Chef's Lard Flight</p>
+          <p className="mt-4 text-2xl text-muted-foreground">
+            Three textures of rendered, whipped, and cured lard with bread.
+          </p>
+          <p className="mt-8 text-5xl font-bold">$28</p>
+        </SignagePanel>
+      </div>
+    </SignageContainer>
+  );
+};`;
+
+const buildPromptCode = `@signage-architect
+
+Build a landscape 1920x1080 restaurant signage screen set for The Lard Lounge.
+
+Use the design brief in docs/signage design briefs/The Lard Lounge/.
+Create:
+- dinner menu screen using Category Columns
+- featured special screen using Feature Pair + Hero
+- fallback closed screen for offline or after-hours states
+
+Keep item names and prices readable from 3-5 metres.
+Use @wallrun/shadcnui-signage components where they fit.
+Avoid dense paragraph copy and keep the menu data in a typed data file.`;
+
+const deployCode = `pnpm nx g wallrun:player-app --name player-lard-lounge --displayOrientation landscape
+pnpm nx serve player-lard-lounge
+pnpm deploy:player -- --app player-lard-lounge --player dining-room-display`;
+
+const SectionHeading: FC<{
+  eyebrow: string;
+  title: string;
+  icon: typeof Monitor;
+}> = ({ eyebrow, title, icon: Icon }) => {
+  return (
+    <div className="mb-5 flex items-start gap-3">
+      <div className="rounded-md bg-muted p-2 text-muted-foreground">
+        <Icon className="h-5 w-5" />
+      </div>
+      <div>
+        <p className="text-sm text-muted-foreground">{eyebrow}</p>
+        <h2 className="text-2xl font-medium text-foreground">{title}</h2>
+      </div>
+    </div>
+  );
+};
+
+const CheckItem: FC<{ children: string }> = ({ children }) => {
+  return (
+    <li className="flex gap-2">
+      <CheckCircle className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+      <span>{children}</span>
+    </li>
+  );
+};
+
+export const RestaurantDigitalSignageTutorialPage: FC = () => {
+  return (
+    <div className="doc-shell max-w-5xl font-sans">
+      <div className="demo-panel demo-grid mb-10 space-y-4 px-8 py-8 sm:px-10">
+        <p className="text-sm text-muted-foreground">Tutorial</p>
+
+        <h1 className="display-type text-3xl text-foreground md:text-4xl">
+          Create Restaurant Digital Signage With WallRun
+        </h1>
+
+        <p className="max-w-3xl text-base text-muted-foreground md:text-lg">
+          A start-to-finish developer case study for The Lard Lounge, a modern
+          restaurant devoted to the surprisingly serious art of lard-based
+          dishes.
+        </p>
+      </div>
+
+      <section className="demo-panel-soft mb-8 px-8 py-8 sm:px-10">
+        <SectionHeading
+          eyebrow="Case study"
+          title="The Brief"
+          icon={ClipboardList}
+        />
+        <div className="space-y-4 text-muted-foreground">
+          <p>
+            The Lard Lounge is fictional, but the workflow is the one you would
+            use for a real restaurant: define the venue, reduce the menu to a
+            readable screen system, build with WallRun components, and verify it
+            as unattended display software.
+          </p>
+          <div className="grid gap-4 md:grid-cols-3">
+            <div className="rounded-lg border border-border bg-card p-4">
+              <h3 className="mb-2 font-medium text-foreground">Venue</h3>
+              <p className="text-sm">
+                Modern dining room, counter ordering at lunch, table service at
+                dinner, open kitchen, warm lighting.
+              </p>
+            </div>
+            <div className="rounded-lg border border-border bg-card p-4">
+              <h3 className="mb-2 font-medium text-foreground">Audience</h3>
+              <p className="text-sm">
+                Curious food people who enjoy craft, humour, and clear pricing
+                before they commit to the full lard journey.
+              </p>
+            </div>
+            <div className="rounded-lg border border-border bg-card p-4">
+              <h3 className="mb-2 font-medium text-foreground">Screens</h3>
+              <p className="text-sm">
+                One landscape menu board above the counter, one rotating
+                specials screen near the host stand, one closed fallback.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="demo-panel mb-8 px-8 py-8 sm:px-10">
+        <SectionHeading
+          eyebrow="Step 1"
+          title="Turn the Restaurant Into a Signage System"
+          icon={Utensils}
+        />
+        <div className="space-y-4 text-muted-foreground">
+          <p>
+            Start by deciding what the screens must do in the room. The counter
+            board must answer three questions quickly: what is sold, what does
+            it cost, and what should I order if I am overwhelmed by a menu full
+            of rendered fat.
+          </p>
+          <ul className="space-y-2 text-sm">
+            <CheckItem>
+              Dinner menu screen: Category Columns template for repeatable item
+              and price scanning.
+            </CheckItem>
+            <CheckItem>
+              Featured special screen: Feature Pair + Hero template for the
+              Chef's Lard Flight and seasonal plate.
+            </CheckItem>
+            <CheckItem>
+              Closed fallback screen: short message, reopening time, QR prompt,
+              and no dependency on live menu data.
+            </CheckItem>
+          </ul>
+          <p>
+            This is where WallRun differs from slide-based signage. We are
+            designing a small app surface with data, states, and fallbacks, not
+            a one-off graphic.
+          </p>
+        </div>
+      </section>
+
+      <section className="demo-panel-soft mb-8 px-8 py-8 sm:px-10">
+        <SectionHeading
+          eyebrow="Step 2"
+          title="Define the Brand Rules"
+          icon={Palette}
+        />
+        <div className="grid gap-4 text-sm text-muted-foreground md:grid-cols-2">
+          <div className="rounded-lg border border-border bg-card p-4">
+            <h3 className="mb-2 font-medium text-foreground">Palette</h3>
+            <p>
+              Charcoal, bone white, copper pan, preserved lemon, and a sharp
+              parsley green. The page should feel modern and edible, not brown
+              and heavy.
+            </p>
+          </div>
+          <div className="rounded-lg border border-border bg-card p-4">
+            <h3 className="mb-2 font-medium text-foreground">Type</h3>
+            <p>
+              Wide, confident display headings for the venue name; practical
+              sans-serif item names and tabular prices for scan speed.
+            </p>
+          </div>
+          <div className="rounded-lg border border-border bg-card p-4">
+            <h3 className="mb-2 font-medium text-foreground">Imagery</h3>
+            <p>
+              Close food photography with crisp edges, steam, and ceramic
+              plates. Avoid novelty fat imagery that makes the offer look like a
+              joke.
+            </p>
+          </div>
+          <div className="rounded-lg border border-border bg-card p-4">
+            <h3 className="mb-2 font-medium text-foreground">Voice</h3>
+            <p>
+              Self-aware but precise: "crispy", "cultured", "slow-rendered",
+              "brightened with pickle" instead of paragraph-length romance.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section className="demo-panel mb-8 px-8 py-8 sm:px-10">
+        <SectionHeading
+          eyebrow="Step 3"
+          title="Model the Menu Before the Layout"
+          icon={BadgeDollarSign}
+        />
+        <div className="space-y-4 text-muted-foreground">
+          <p>
+            Menu boards fail when content arrives as freeform copy. Keep the
+            data small and explicit: categories, item names, short descriptions,
+            prices, and optional tags.
+          </p>
+          <CodeSnippet
+            language="typescript"
+            filename="lardLoungeMenu.ts"
+            code={menuDataCode}
+          />
+          <p className="text-sm">
+            If a category grows beyond eight to twelve items in landscape, split
+            it into another screen or rotate modes. Do not keep shrinking text
+            until the menu technically fits but nobody can read it.
+          </p>
+        </div>
+      </section>
+
+      <section className="demo-panel-soft mb-8 px-8 py-8 sm:px-10">
+        <SectionHeading
+          eyebrow="Step 4"
+          title="Choose WallRun Components"
+          icon={LayoutTemplate}
+        />
+        <div className="space-y-4 text-muted-foreground">
+          <p>
+            For a restaurant menu board, start with the signage primitives and
+            blocks instead of composing raw cards from scratch.
+          </p>
+          <div className="grid gap-4 md:grid-cols-2">
+            <div className="rounded-lg border border-border bg-card p-4">
+              <h3 className="mb-2 font-medium text-foreground">
+                Screen structure
+              </h3>
+              <p className="text-sm">
+                Use SignageContainer, SignageHeader, SignagePanel, and
+                SplitScreen when you need fixed screen zones and safe spacing.
+              </p>
+            </div>
+            <div className="rounded-lg border border-border bg-card p-4">
+              <h3 className="mb-2 font-medium text-foreground">Menu content</h3>
+              <p className="text-sm">
+                Use MenuBoard, MenuSection, and MenuItem when price alignment
+                and repeated item hierarchy matter more than decoration.
+              </p>
+            </div>
+            <div className="rounded-lg border border-border bg-card p-4">
+              <h3 className="mb-2 font-medium text-foreground">
+                Runtime states
+              </h3>
+              <p className="text-sm">
+                Add ScheduleGate, OfflineFallback, StaleDataIndicator, and
+                ContentRotator when data or daypart changes can fail.
+              </p>
+            </div>
+            <div className="rounded-lg border border-border bg-card p-4">
+              <h3 className="mb-2 font-medium text-foreground">Verification</h3>
+              <p className="text-sm">
+                Test at the target aspect ratio, then check the page as a
+                full-screen unattended display.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="demo-panel mb-8 px-8 py-8 sm:px-10">
+        <SectionHeading
+          eyebrow="Step 5"
+          title="Build the First Screen"
+          icon={Code}
+        />
+        <div className="space-y-4 text-muted-foreground">
+          <p>
+            The first implementation can be simple: one menu board field, one
+            featured panel, and menu data imported from a typed file. That gives
+            you a real surface for review without committing to animation or
+            live pricing too early.
+          </p>
+          <CodeSnippet
+            language="tsx"
+            filename="LardLoungeMenuScreen.tsx"
+            code={componentCode}
+          />
+          <p className="text-sm">
+            Once the static screen reads clearly, add daypart switching or live
+            menu data. Dynamic behavior is a second pass, not a substitute for
+            hierarchy.
+          </p>
+        </div>
+      </section>
+
+      <section className="demo-panel-soft mb-8 px-8 py-8 sm:px-10">
+        <SectionHeading
+          eyebrow="Step 6"
+          title="Use the WallRun Agent Workflow"
+          icon={Monitor}
+        />
+        <div className="space-y-4 text-muted-foreground">
+          <p>
+            If you are working inside the WallRun repository, the agent workflow
+            can turn this brief into a player app and keep the implementation
+            aligned with signage constraints.
+          </p>
+          <CodeSnippet
+            language="bash"
+            filename="Copilot Chat prompt"
+            code={buildPromptCode}
+          />
+          <p>
+            The important detail is the shape of the ask. Name the venue, point
+            to the brief, specify screen inventory, name the templates, and make
+            legibility a requirement.
+          </p>
+        </div>
+      </section>
+
+      <section className="demo-panel mb-8 px-8 py-8 sm:px-10">
+        <SectionHeading
+          eyebrow="Step 7"
+          title="Package, Preview, and Deploy"
+          icon={Package}
+        />
+        <div className="space-y-4 text-muted-foreground">
+          <p>
+            For hardware, scaffold a player app, preview it locally, then deploy
+            to a registered display. The exact target player name depends on
+            your local configuration.
+          </p>
+          <CodeSnippet language="bash" filename="terminal" code={deployCode} />
+          <ul className="space-y-2 text-sm">
+            <CheckItem>
+              Preview at the target orientation and resolution before packaging.
+            </CheckItem>
+            <CheckItem>
+              Confirm item names, prices, and service notes are readable from
+              the intended viewing distance.
+            </CheckItem>
+            <CheckItem>
+              Test missing menu data and after-hours behavior before the screen
+              goes on a wall.
+            </CheckItem>
+          </ul>
+        </div>
+      </section>
+
+      <section className="demo-panel-soft mb-8 px-8 py-8 sm:px-10">
+        <SectionHeading
+          eyebrow="Outcome"
+          title="What The Lard Lounge Gets"
+          icon={CheckCircle}
+        />
+        <div className="space-y-4 text-muted-foreground">
+          <p>
+            By the end, The Lard Lounge has a small screen system rather than a
+            pile of static images: a menu screen, a featured special screen, and
+            a resilient fallback. Developers can update menu data, swap assets,
+            test behavior, and deploy the same way they would ship a frontend
+            app.
+          </p>
+          <p>
+            The joke is lard. The serious bit is that restaurant signage is
+            operational software: prices change, availability changes, service
+            modes change, and the display has to stay legible when the dining
+            room gets loud.
+          </p>
+        </div>
+      </section>
+
+      <section className="demo-panel px-8 py-8 sm:px-10">
+        <h2 className="mb-4 text-2xl font-medium text-foreground">
+          Continue the Workflow
+        </h2>
+        <div className="flex flex-wrap gap-3">
+          <Button asChild variant="secondary" className="h-11">
+            <Link to="/components/blocks/menu-board">Open MenuBoard docs</Link>
+          </Button>
+          <Button asChild variant="outline" className="h-11">
+            <Link to="/how-to/design-brief">Create a design brief</Link>
+          </Button>
+          <Button asChild variant="ghost" className="h-11">
+            <Link to="/tooling">Review deployment tooling</Link>
+          </Button>
+        </div>
+      </section>
+    </div>
+  );
+};

--- a/apps/client/src/app/pages/tutorials/Tutorials.test.tsx
+++ b/apps/client/src/app/pages/tutorials/Tutorials.test.tsx
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { BrowserRouter } from 'react-router-dom';
+import { TutorialsPage } from './Tutorials';
+
+describe('TutorialsPage', () => {
+  const renderWithRouter = () => {
+    return render(
+      <BrowserRouter>
+        <TutorialsPage />
+      </BrowserRouter>,
+    );
+  };
+
+  it('renders the tutorials page title', () => {
+    renderWithRouter();
+    expect(
+      screen.getByText('Build Signage Like a Project'),
+    ).toBeInTheDocument();
+  });
+
+  it('links to the restaurant signage tutorial', () => {
+    renderWithRouter();
+    const link = screen.getByRole('link', {
+      name: /restaurant digital signage from scratch/i,
+    });
+
+    expect(link).toHaveAttribute(
+      'href',
+      '/tutorials/restaurant-digital-signage',
+    );
+  });
+
+  it('explains the tutorial format', () => {
+    renderWithRouter();
+    expect(screen.getByText('Tutorial Format')).toBeInTheDocument();
+    expect(screen.getByText('Start with context')).toBeInTheDocument();
+    expect(screen.getByText('Model the content')).toBeInTheDocument();
+    expect(screen.getByText('Finish with checks')).toBeInTheDocument();
+  });
+});

--- a/apps/client/src/app/pages/tutorials/Tutorials.tsx
+++ b/apps/client/src/app/pages/tutorials/Tutorials.tsx
@@ -1,0 +1,134 @@
+import { FC } from 'react';
+import { Link } from 'react-router-dom';
+import { ArrowRight, BookOpen, Monitor, Utensils } from 'lucide-react';
+
+type Tutorial = {
+  title: string;
+  description: string;
+  path: string;
+  duration: string;
+  audience: string;
+};
+
+const tutorials: Tutorial[] = [
+  {
+    title: 'Restaurant Digital Signage From Scratch',
+    description:
+      'Invent The Lard Lounge, turn the concept into a signage brief, model the menu data, choose WallRun components, and build a production-minded restaurant screen set.',
+    path: '/tutorials/restaurant-digital-signage',
+    duration: '45-60 min',
+    audience: 'React developers building restaurant signage',
+  },
+];
+
+const TutorialCard: FC<{ tutorial: Tutorial }> = ({ tutorial }) => {
+  return (
+    <Link
+      to={tutorial.path}
+      className="group block rounded-lg border border-border bg-card p-6 transition-colors hover:border-foreground/20 hover:bg-accent"
+    >
+      <div className="mb-5 flex items-start justify-between gap-4">
+        <div className="rounded-md bg-muted p-2 text-muted-foreground">
+          <Utensils className="h-5 w-5" />
+        </div>
+        <ArrowRight className="mt-2 h-5 w-5 text-muted-foreground transition-transform group-hover:translate-x-1 group-hover:text-foreground" />
+      </div>
+
+      <h3 className="mb-2 text-lg font-medium text-foreground group-hover:text-accent-foreground">
+        {tutorial.title}
+      </h3>
+      <p className="mb-5 text-sm text-muted-foreground">
+        {tutorial.description}
+      </p>
+
+      <dl className="grid gap-3 text-sm text-muted-foreground sm:grid-cols-2">
+        <div>
+          <dt className="text-xs uppercase tracking-wide text-muted-foreground">
+            Time
+          </dt>
+          <dd className="mt-1 text-foreground">{tutorial.duration}</dd>
+        </div>
+        <div>
+          <dt className="text-xs uppercase tracking-wide text-muted-foreground">
+            Audience
+          </dt>
+          <dd className="mt-1 text-foreground">{tutorial.audience}</dd>
+        </div>
+      </dl>
+    </Link>
+  );
+};
+
+export const TutorialsPage: FC = () => {
+  return (
+    <div className="doc-shell max-w-5xl font-sans">
+      <div className="demo-panel demo-grid mb-10 space-y-4 px-8 py-8 sm:px-10">
+        <p className="text-sm text-muted-foreground">Tutorials</p>
+
+        <h1 className="display-type text-3xl text-foreground md:text-4xl">
+          Build Signage Like a Project
+        </h1>
+
+        <p className="max-w-2xl text-base text-muted-foreground md:text-lg">
+          Longer-form walkthroughs that turn a venue brief into real WallRun
+          screens, data shapes, component choices, runtime notes, and deployment
+          checks.
+        </p>
+      </div>
+
+      <section className="mb-8">
+        <h2 className="mb-4 px-2 text-xl font-medium text-foreground">
+          Featured Tutorial
+        </h2>
+        <div className="space-y-4">
+          {tutorials.map((tutorial) => (
+            <TutorialCard key={tutorial.path} tutorial={tutorial} />
+          ))}
+        </div>
+      </section>
+
+      <section className="demo-panel-soft px-8 py-8 sm:px-10">
+        <div className="mb-5 flex items-center gap-3">
+          <div className="rounded-md bg-muted p-2 text-muted-foreground">
+            <BookOpen className="h-5 w-5" />
+          </div>
+          <h2 className="text-2xl font-medium text-foreground">
+            Tutorial Format
+          </h2>
+        </div>
+        <div className="grid gap-4 text-sm text-muted-foreground md:grid-cols-3">
+          <div className="rounded-lg border border-border bg-card p-4">
+            <Monitor className="mb-3 h-5 w-5 text-muted-foreground" />
+            <h3 className="mb-2 font-medium text-foreground">
+              Start with context
+            </h3>
+            <p>
+              Define the venue, audience, service model, screens, and failure
+              cases before writing components.
+            </p>
+          </div>
+          <div className="rounded-lg border border-border bg-card p-4">
+            <Utensils className="mb-3 h-5 w-5 text-muted-foreground" />
+            <h3 className="mb-2 font-medium text-foreground">
+              Model the content
+            </h3>
+            <p>
+              Shape real menu or operational data so the UI can stay readable,
+              testable, and easy to change.
+            </p>
+          </div>
+          <div className="rounded-lg border border-border bg-card p-4">
+            <ArrowRight className="mb-3 h-5 w-5 text-muted-foreground" />
+            <h3 className="mb-2 font-medium text-foreground">
+              Finish with checks
+            </h3>
+            <p>
+              Validate distance legibility, safe zones, data fallback behavior,
+              and the player packaging path.
+            </p>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+};

--- a/docs/plans/2026-05-04-add-restaurant-tutorial.md
+++ b/docs/plans/2026-05-04-add-restaurant-tutorial.md
@@ -1,0 +1,40 @@
+# Add Restaurant Tutorial Section
+
+## Goal
+
+Add a Tutorials section to the WallRun demo site and launch it with a comprehensive restaurant digital signage case study.
+
+## Context
+
+The demo site already has short how-to pages for design briefs, signage builds, agents, and BrightSign deployment. The new tutorial should be longer-form and narrative: a start-to-finish developer case study for inventing a restaurant concept, structuring menu data, choosing WallRun tools and components, implementing screens, and preparing for deployment.
+
+The first tutorial uses the invented venue "The Lard Lounge", a modern restaurant where all dishes are lard based.
+
+## Task Breakdown
+
+- Add a tutorial index page at `/tutorials`.
+- Add a detailed case-study tutorial route at `/tutorials/restaurant-digital-signage`.
+- Wire the section into sidebar navigation and route configuration.
+- Keep the content developer-oriented while preserving signage-specific constraints: venue profile, brand profile, data model, screen inventory, component choices, runtime fallbacks, and verification.
+- Add focused render/link tests for the new pages.
+
+## Files To Change
+
+- `apps/client/src/app/constants/navigationConfig.ts`
+- `apps/client/src/app/pages/tutorials/Tutorials.tsx`
+- `apps/client/src/app/pages/tutorials/Tutorials.test.tsx`
+- `apps/client/src/app/pages/tutorials/RestaurantDigitalSignage.tsx`
+- `apps/client/src/app/pages/tutorials/RestaurantDigitalSignage.test.tsx`
+
+## Commands To Run
+
+- `pnpm test:client`
+- `pnpm type-check:client`
+- `pnpm verify` if time and environment allow
+
+## Expected Results
+
+- The demo site sidebar includes a Tutorials section.
+- `/tutorials` links to the restaurant tutorial.
+- `/tutorials/restaurant-digital-signage` reads as a practical case study for building restaurant signage with WallRun tools and components.
+- Tests and type checking pass.

--- a/docs/plans/2026-05-04-add-restaurant-tutorial.md
+++ b/docs/plans/2026-05-04-add-restaurant-tutorial.md
@@ -8,7 +8,7 @@ Add a Tutorials section to the WallRun demo site and launch it with a comprehens
 
 The demo site already has short how-to pages for design briefs, signage builds, agents, and BrightSign deployment. The new tutorial should be longer-form and narrative: a start-to-finish developer case study for inventing a restaurant concept, structuring menu data, choosing WallRun tools and components, implementing screens, and preparing for deployment.
 
-The first tutorial uses the invented venue "The Lard Lounge", a modern restaurant where all dishes are lard based.
+The first tutorial uses the invented venue "The Lard Lounge", a modern restaurant where all dishes are lard-based.
 
 ## Task Breakdown
 


### PR DESCRIPTION
## Summary
This PR adds a new Tutorials section to the client demo site and launches it with a longer-form restaurant signage walkthrough.

### What changed
- add a Tutorials section to the sidebar and route configuration
- add a Tutorials index page at `/tutorials`
- add a detailed case-study page at `/tutorials/restaurant-digital-signage`
- add focused render and link tests for both new tutorial pages
- add a work plan document under `docs/plans`

### Tutorial content
The new tutorial is a developer-oriented case study built around the fictional restaurant "The Lard Lounge". It walks through:
- defining the venue and signage brief
- turning the concept into a screen system
- modeling menu data before layout work
- selecting WallRun signage components
- building an initial screen implementation
- using the WallRun agent workflow
- packaging, previewing, and deploying to a player

## Verification
`pnpm verify`

Results:
- format check: passed
- affected lint: passed (`client`, `storybook-host`, `client-e2e`)
- affected type-check: passed (`client`)
- affected tests: passed
  - `24` client test files passed
  - `113` client tests passed
  - `1` storybook-host test file passed
  - `1` storybook-host test passed
- affected build: passed (`client`, `storybook-host` and dependent tasks)

## Notes
- Vitest emitted existing React Router future-flag warnings during tests.
- The client production build emitted a non-blocking Vite chunk-size warning for a large JS bundle (`index-BVGtdeyw.js` at `985.51 kB`, `272.04 kB` gzip).