### PR TITLE
Add signage fallback primitives and registry item endpoints

### DIFF
--- a/.github/instructions/00-repo-basics.instructions.md
+++ b/.github/instructions/00-repo-basics.instructions.md
@@ -150,7 +150,7 @@ When updating `apps/client/public/registry/registry.json`:
 - Exclude React and workspace packages (`@wallrun/*`)
 - Use `"type": "registry:component"` for components, `"registry:lib"` for utilities
 - Descriptions must match actual behavior (read the code, don't copy from similar components)
-- Installation format: `npx shadcn@latest add https://cambridgemonorail.github.io/WallRun/registry/registry.json component-name`
+- Installation format: `npx shadcn@latest add https://wallrun.dev/registry/component-name.json`
 
 ### Library Documentation
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Components are in `libs/shadcnui-signage/` with:
 The signage components are distributed through a shadcn-compatible registry. Install them into your own project with:
 
 ```bash
-npx shadcn@latest add https://cambridgemonorail.github.io/WallRun/registry/registry.json auto-paging-list
+npx shadcn@latest add https://wallrun.dev/registry/auto-paging-list.json
 ```
 
 You can also browse the available components and installation options in:

--- a/apps/client/public/ai-context.md
+++ b/apps/client/public/ai-context.md
@@ -15,7 +15,7 @@ The project combines:
 - `https://wallrun.dev/llms.txt`: curated index for AI consumers
 - `https://wallrun.dev/library.md`: high-level library overview
 - `https://wallrun.dev/components.md`: installable component catalogue
-- `https://cambridgemonorail.github.io/WallRun/registry/registry.json`: shadcn registry source
+- `https://wallrun.dev/registry/registry.json`: shadcn registry index for discovery and `--all`
 - `https://cambridgemonorail.github.io/WallRun/storybook/?path=/docs/introduction--documentation`: interactive docs
 
 ## Canonical Human Interfaces

--- a/apps/client/public/components.md
+++ b/apps/client/public/components.md
@@ -10,12 +10,12 @@ This file is the machine-readable component catalogue for the installable WallRu
 
 Registry JSON:
 
-- `https://cambridgemonorail.github.io/WallRun/registry/registry.json`
+- `https://wallrun.dev/registry/registry.json`
 
 Install command pattern:
 
 ```bash
-npx shadcn@latest add https://cambridgemonorail.github.io/WallRun/registry/registry.json <component-name>
+npx shadcn@latest add https://wallrun.dev/registry/<component-name>.json
 ```
 
 ## Catalogue
@@ -25,309 +25,309 @@ npx shadcn@latest add https://cambridgemonorail.github.io/WallRun/registry/regis
 - Name: `metric-card`
 - Category: Primitive
 - Purpose: KPI and numeric status display for dashboards and operations screens.
-- Install: `npx shadcn@latest add https://cambridgemonorail.github.io/WallRun/registry/registry.json metric-card`
+- Install: `npx shadcn@latest add https://wallrun.dev/registry/metric-card.json`
 - Usage guidance: use for concise values, deltas, and icon-backed metric highlights.
 - Do not use for: long narrative copy, schedules, or multi-row lists.
 - Dependencies: `clsx`, `lucide-react`, `tailwind-merge`
 - Source path: `libs/shadcnui-signage/src/lib/primitives/MetricCard.tsx`
-- Registry JSON: `https://cambridgemonorail.github.io/WallRun/registry/registry.json`
+- Registry JSON: `https://wallrun.dev/registry/registry.json`
 
 ### Screen Frame
 
 - Name: `screen-frame`
 - Category: Primitive
 - Purpose: preview container with aspect-ratio and safe-area guides for development and QA.
-- Install: `npx shadcn@latest add https://cambridgemonorail.github.io/WallRun/registry/registry.json screen-frame`
+- Install: `npx shadcn@latest add https://wallrun.dev/registry/screen-frame.json`
 - Usage guidance: use in demos, previews, QA tools, and authoring workflows.
 - Do not use for: the real production screen shell of a deployed signage app.
 - Dependencies: none
 - Source path: `libs/shadcnui-signage/src/lib/primitives/ScreenFrame.tsx`
-- Registry JSON: `https://cambridgemonorail.github.io/WallRun/registry/registry.json`
+- Registry JSON: `https://wallrun.dev/registry/registry.json`
 
 ### Event Card
 
 - Name: `event-card`
 - Category: Primitive
 - Purpose: event, schedule, and conference slot card with time, speaker, and location metadata.
-- Install: `npx shadcn@latest add https://cambridgemonorail.github.io/WallRun/registry/registry.json event-card`
+- Install: `npx shadcn@latest add https://wallrun.dev/registry/event-card.json`
 - Usage guidance: use for schedule boards and venue/event programming.
 - Do not use for: KPI summaries or alert-heavy fallback states.
 - Dependencies: `clsx`, `lucide-react`, `tailwind-merge`
 - Source path: `libs/shadcnui-signage/src/lib/primitives/EventCard.tsx`
-- Registry JSON: `https://cambridgemonorail.github.io/WallRun/registry/registry.json`
+- Registry JSON: `https://wallrun.dev/registry/registry.json`
 
 ### Announcement Card
 
 - Name: `announcement-card`
 - Category: Primitive
 - Purpose: headline-and-description announcement card for notices and updates.
-- Install: `npx shadcn@latest add https://cambridgemonorail.github.io/WallRun/registry/registry.json announcement-card`
+- Install: `npx shadcn@latest add https://wallrun.dev/registry/announcement-card.json`
 - Usage guidance: use for announcements, alerts, and short informational messages.
 - Do not use for: dense tabular content or operational lists.
 - Dependencies: `clsx`, `lucide-react`, `tailwind-merge`
 - Source path: `libs/shadcnui-signage/src/lib/primitives/AnnouncementCard.tsx`
-- Registry JSON: `https://cambridgemonorail.github.io/WallRun/registry/registry.json`
+- Registry JSON: `https://wallrun.dev/registry/registry.json`
 
 ### Directory Card
 
 - Name: `directory-card`
 - Category: Primitive
 - Purpose: wayfinding card with department, floor, room, and contact metadata.
-- Install: `npx shadcn@latest add https://cambridgemonorail.github.io/WallRun/registry/registry.json directory-card`
+- Install: `npx shadcn@latest add https://wallrun.dev/registry/directory-card.json`
 - Usage guidance: use for directory walls, office lobbies, and room-finding screens.
 - Do not use for: menu boards or event timeline cards.
 - Dependencies: `clsx`, `tailwind-merge`
 - Source path: `libs/shadcnui-signage/src/lib/primitives/DirectoryCard.tsx`
-- Registry JSON: `https://cambridgemonorail.github.io/WallRun/registry/registry.json`
+- Registry JSON: `https://wallrun.dev/registry/registry.json`
 
 ### Floor Badge
 
 - Name: `floor-badge`
 - Category: Primitive
 - Purpose: compact floor or zone label for wayfinding overlays.
-- Install: `npx shadcn@latest add https://cambridgemonorail.github.io/WallRun/registry/registry.json floor-badge`
+- Install: `npx shadcn@latest add https://wallrun.dev/registry/floor-badge.json`
 - Usage guidance: use as supporting location metadata inside wayfinding layouts.
 - Do not use for: primary page titles or large CTA states.
 - Dependencies: `clsx`, `tailwind-merge`
 - Source path: `libs/shadcnui-signage/src/lib/primitives/FloorBadge.tsx`
-- Registry JSON: `https://cambridgemonorail.github.io/WallRun/registry/registry.json`
+- Registry JSON: `https://wallrun.dev/registry/registry.json`
 
 ### Location Indicator
 
 - Name: `location-indicator`
 - Category: Primitive
 - Purpose: current-location marker with pin-style iconography for maps and directories.
-- Install: `npx shadcn@latest add https://cambridgemonorail.github.io/WallRun/registry/registry.json location-indicator`
+- Install: `npx shadcn@latest add https://wallrun.dev/registry/location-indicator.json`
 - Usage guidance: use as contextual location state inside wayfinding UIs.
 - Do not use for: destination lists or schedule rows.
 - Dependencies: `clsx`, `lucide-react`, `tailwind-merge`
 - Source path: `libs/shadcnui-signage/src/lib/primitives/LocationIndicator.tsx`
-- Registry JSON: `https://cambridgemonorail.github.io/WallRun/registry/registry.json`
+- Registry JSON: `https://wallrun.dev/registry/registry.json`
 
 ### Menu Item
 
 - Name: `menu-item`
 - Category: Primitive
 - Purpose: menu row with name, price, and optional description.
-- Install: `npx shadcn@latest add https://cambridgemonorail.github.io/WallRun/registry/registry.json menu-item`
+- Install: `npx shadcn@latest add https://wallrun.dev/registry/menu-item.json`
 - Usage guidance: use inside restaurant, cafe, and concessions menu sections.
 - Do not use for: generic ecommerce cards or schedule cards.
 - Dependencies: `clsx`, `tailwind-merge`
 - Source path: `libs/shadcnui-signage/src/lib/primitives/MenuItem.tsx`
-- Registry JSON: `https://cambridgemonorail.github.io/WallRun/registry/registry.json`
+- Registry JSON: `https://wallrun.dev/registry/registry.json`
 
 ### Menu Section
 
 - Name: `menu-section`
 - Category: Primitive
 - Purpose: grouped section wrapper for menu categories.
-- Install: `npx shadcn@latest add https://cambridgemonorail.github.io/WallRun/registry/registry.json menu-section`
+- Install: `npx shadcn@latest add https://wallrun.dev/registry/menu-section.json`
 - Usage guidance: use to group related menu items with a visible heading and divider.
 - Do not use for: dashboards or directory panels.
 - Dependencies: `clsx`, `tailwind-merge`
 - Source path: `libs/shadcnui-signage/src/lib/primitives/MenuSection.tsx`
-- Registry JSON: `https://cambridgemonorail.github.io/WallRun/registry/registry.json`
+- Registry JSON: `https://wallrun.dev/registry/registry.json`
 
 ### Signage Panel
 
 - Name: `signage-panel`
 - Category: Primitive
 - Purpose: bordered content panel for grouped supporting information.
-- Install: `npx shadcn@latest add https://cambridgemonorail.github.io/WallRun/registry/registry.json signage-panel`
+- Install: `npx shadcn@latest add https://wallrun.dev/registry/signage-panel.json`
 - Usage guidance: use for side panels, support zones, and secondary information blocks.
 - Do not use for: full-screen hero messaging.
 - Dependencies: `clsx`, `tailwind-merge`
 - Source path: `libs/shadcnui-signage/src/lib/primitives/SignagePanel.tsx`
-- Registry JSON: `https://cambridgemonorail.github.io/WallRun/registry/registry.json`
+- Registry JSON: `https://wallrun.dev/registry/registry.json`
 
 ### Meeting Row
 
 - Name: `meeting-row`
 - Category: Primitive
 - Purpose: agenda-style row for room booking and meeting schedules.
-- Install: `npx shadcn@latest add https://cambridgemonorail.github.io/WallRun/registry/registry.json meeting-row`
+- Install: `npx shadcn@latest add https://wallrun.dev/registry/meeting-row.json`
 - Usage guidance: use in operational schedules and office lobby meeting lists.
 - Do not use for: hero states or menu pricing.
 - Dependencies: `clsx`, `tailwind-merge`
 - Source path: `libs/shadcnui-signage/src/lib/primitives/MeetingRow.tsx`
-- Registry JSON: `https://cambridgemonorail.github.io/WallRun/registry/registry.json`
+- Registry JSON: `https://wallrun.dev/registry/registry.json`
 
 ### Info List
 
 - Name: `info-list`
 - Category: Primitive
 - Purpose: large-format list for notices, visitor instructions, and operational notes.
-- Install: `npx shadcn@latest add https://cambridgemonorail.github.io/WallRun/registry/registry.json info-list`
+- Install: `npx shadcn@latest add https://wallrun.dev/registry/info-list.json`
 - Usage guidance: use for short, glanceable bullet-style information.
 - Do not use for: metric-heavy dashboards or event grids.
 - Dependencies: `clsx`, `tailwind-merge`
 - Source path: `libs/shadcnui-signage/src/lib/primitives/InfoList.tsx`
-- Registry JSON: `https://cambridgemonorail.github.io/WallRun/registry/registry.json`
+- Registry JSON: `https://wallrun.dev/registry/registry.json`
 
 ### Split Screen
 
 - Name: `split-screen`
 - Category: Layout
 - Purpose: two-panel layout with configurable ratio and direction.
-- Install: `npx shadcn@latest add https://cambridgemonorail.github.io/WallRun/registry/registry.json split-screen`
+- Install: `npx shadcn@latest add https://wallrun.dev/registry/split-screen.json`
 - Usage guidance: use for paired content zones on known display resolutions.
 - Do not use for: highly dynamic responsive webpage layouts.
 - Dependencies: `clsx`, `tailwind-merge`
 - Source path: `libs/shadcnui-signage/src/lib/layouts/SplitScreen.tsx`
-- Registry JSON: `https://cambridgemonorail.github.io/WallRun/registry/registry.json`
+- Registry JSON: `https://wallrun.dev/registry/registry.json`
 
 ### Signage Container
 
 - Name: `signage-container`
 - Category: Layout
 - Purpose: full-screen container with variant styling, ambient orbs, and optional grid treatment.
-- Install: `npx shadcn@latest add https://cambridgemonorail.github.io/WallRun/registry/registry.json signage-container`
+- Install: `npx shadcn@latest add https://wallrun.dev/registry/signage-container.json`
 - Usage guidance: use as the main app-facing shell for real signage screens.
 - Do not use for: preview-only framing; use `screen-frame` for that.
 - Dependencies: `clsx`, `tailwind-merge`
 - Source path: `libs/shadcnui-signage/src/lib/layouts/SignageContainer.tsx`
-- Registry JSON: `https://cambridgemonorail.github.io/WallRun/registry/registry.json`
+- Registry JSON: `https://wallrun.dev/registry/registry.json`
 
 ### Signage Header
 
 - Name: `signage-header`
 - Category: Layout
 - Purpose: standard signage header with tag, title, and subtitle support.
-- Install: `npx shadcn@latest add https://cambridgemonorail.github.io/WallRun/registry/registry.json signage-header`
+- Install: `npx shadcn@latest add https://wallrun.dev/registry/signage-header.json`
 - Usage guidance: use for page-level framing and hierarchy at the top of a screen.
 - Do not use for: compact card headers inside dense grids.
 - Dependencies: `clsx`, `tailwind-merge`
 - Source path: `libs/shadcnui-signage/src/lib/layouts/SignageHeader.tsx`
-- Registry JSON: `https://cambridgemonorail.github.io/WallRun/registry/registry.json`
+- Registry JSON: `https://wallrun.dev/registry/registry.json`
 
 ### Fullscreen Hero
 
 - Name: `fullscreen-hero`
 - Category: Block
 - Purpose: hero section for welcome states, alerts, and dominant messages.
-- Install: `npx shadcn@latest add https://cambridgemonorail.github.io/WallRun/registry/registry.json fullscreen-hero`
+- Install: `npx shadcn@latest add https://wallrun.dev/registry/fullscreen-hero.json`
 - Usage guidance: use for main-message states where one headline dominates the screen.
 - Do not use for: multi-card dashboards or dense schedules.
 - Dependencies: `clsx`, `tailwind-merge`
 - Source path: `libs/shadcnui-signage/src/lib/blocks/FullscreenHero.tsx`
-- Registry JSON: `https://cambridgemonorail.github.io/WallRun/registry/registry.json`
+- Registry JSON: `https://wallrun.dev/registry/registry.json`
 
 ### Info Card Grid
 
 - Name: `info-card-grid`
 - Category: Block
 - Purpose: grid for small informational cards with values, descriptions, and meta text.
-- Install: `npx shadcn@latest add https://cambridgemonorail.github.io/WallRun/registry/registry.json info-card-grid`
+- Install: `npx shadcn@latest add https://wallrun.dev/registry/info-card-grid.json`
 - Usage guidance: use for grouped promotional or summary cards where each item follows the same structure.
 - Do not use for: freeform card layouts with custom render requirements.
 - Dependencies: `clsx`, `tailwind-merge`
 - Source path: `libs/shadcnui-signage/src/lib/blocks/InfoCardGrid.tsx`
-- Registry JSON: `https://cambridgemonorail.github.io/WallRun/registry/registry.json`
+- Registry JSON: `https://wallrun.dev/registry/registry.json`
 
 ### Menu Board
 
 - Name: `menu-board`
 - Category: Block
 - Purpose: full-screen menu shell for restaurant and daypart signage.
-- Install: `npx shadcn@latest add https://cambridgemonorail.github.io/WallRun/registry/registry.json menu-board`
+- Install: `npx shadcn@latest add https://wallrun.dev/registry/menu-board.json`
 - Usage guidance: use as the top-level shell for menu screens.
 - Do not use for: generic web page layouts or office dashboards.
 - Dependencies: `clsx`, `tailwind-merge`
 - Source path: `libs/shadcnui-signage/src/lib/blocks/MenuBoard.tsx`
-- Registry JSON: `https://cambridgemonorail.github.io/WallRun/registry/registry.json`
+- Registry JSON: `https://wallrun.dev/registry/registry.json`
 
 ### Auto Paging List
 
 - Name: `auto-paging-list`
 - Category: Behaviour
 - Purpose: paginate long lists without scrollbars, advancing automatically between pages.
-- Install: `npx shadcn@latest add https://cambridgemonorail.github.io/WallRun/registry/registry.json auto-paging-list`
+- Install: `npx shadcn@latest add https://wallrun.dev/registry/auto-paging-list.json`
 - Usage guidance: use when content exceeds a fixed display area but still needs calm unattended playback.
 - Do not use for: user-driven scrolling UIs.
 - Dependencies: `clsx`, `tailwind-merge`
 - Source path: `libs/shadcnui-signage/src/lib/behaviour/AutoPagingList.tsx`
-- Registry JSON: `https://cambridgemonorail.github.io/WallRun/registry/registry.json`
+- Registry JSON: `https://wallrun.dev/registry/registry.json`
 
 ### Content Rotator
 
 - Name: `content-rotator`
 - Category: Behaviour
 - Purpose: rotate through children on a fixed interval with signage-safe transitions.
-- Install: `npx shadcn@latest add https://cambridgemonorail.github.io/WallRun/registry/registry.json content-rotator`
+- Install: `npx shadcn@latest add https://wallrun.dev/registry/content-rotator.json`
 - Usage guidance: use for whole-state rotations such as lobby loops, promos, and announcement sequences.
 - Do not use for: fine-grained animation of individual inline elements.
 - Dependencies: `clsx`, `tailwind-merge`
 - Source path: `libs/shadcnui-signage/src/lib/behaviour/ContentRotator.tsx`
-- Registry JSON: `https://cambridgemonorail.github.io/WallRun/registry/registry.json`
+- Registry JSON: `https://wallrun.dev/registry/registry.json`
 
 ### Schedule Gate
 
 - Name: `schedule-gate`
 - Category: Behaviour
 - Purpose: weekday and time-window gating for daypart content.
-- Install: `npx shadcn@latest add https://cambridgemonorail.github.io/WallRun/registry/registry.json schedule-gate`
+- Install: `npx shadcn@latest add https://wallrun.dev/registry/schedule-gate.json`
 - Usage guidance: use to swap or hide content based on known time windows and timezones.
 - Do not use for: arbitrary business rules unrelated to time/day scheduling.
 - Dependencies: `clsx`, `date-fns-tz`, `tailwind-merge`
 - Source path: `libs/shadcnui-signage/src/lib/behaviour/ScheduleGate.tsx`
-- Registry JSON: `https://cambridgemonorail.github.io/WallRun/registry/registry.json`
+- Registry JSON: `https://wallrun.dev/registry/registry.json`
 
 ### Signage Transition
 
 - Name: `signage-transition`
 - Category: Behaviour
 - Purpose: wrap a single child in signage-appropriate crossfade or slide transitions.
-- Install: `npx shadcn@latest add https://cambridgemonorail.github.io/WallRun/registry/registry.json signage-transition`
+- Install: `npx shadcn@latest add https://wallrun.dev/registry/signage-transition.json`
 - Usage guidance: use for explicit content-state transitions that should respect reduced motion.
 - Do not use for: continuous decorative motion.
 - Dependencies: `clsx`, `tailwind-merge`
 - Source path: `libs/shadcnui-signage/src/lib/behaviour/SignageTransition.tsx`
-- Registry JSON: `https://cambridgemonorail.github.io/WallRun/registry/registry.json`
+- Registry JSON: `https://wallrun.dev/registry/registry.json`
 
 ### Clock
 
 - Name: `clock`
 - Category: Behaviour
 - Purpose: current-time display with signage-friendly update cadence.
-- Install: `npx shadcn@latest add https://cambridgemonorail.github.io/WallRun/registry/registry.json clock`
+- Install: `npx shadcn@latest add https://wallrun.dev/registry/clock.json`
 - Usage guidance: use for lobby, office, and status screens that need a visible clock.
 - Do not use for: countdown or elapsed-time flows.
 - Dependencies: `clsx`, `tailwind-merge`
 - Source path: `libs/shadcnui-signage/src/lib/behaviour/Clock.tsx`
-- Registry JSON: `https://cambridgemonorail.github.io/WallRun/registry/registry.json`
+- Registry JSON: `https://wallrun.dev/registry/registry.json`
 
 ### Countdown
 
 - Name: `countdown`
 - Category: Behaviour
 - Purpose: countdown to a target date/time with clamped zero state.
-- Install: `npx shadcn@latest add https://cambridgemonorail.github.io/WallRun/registry/registry.json countdown`
+- Install: `npx shadcn@latest add https://wallrun.dev/registry/countdown.json`
 - Usage guidance: use for events, deadlines, and timed launches.
 - Do not use for: current-time display.
 - Dependencies: `clsx`, `tailwind-merge`
 - Source path: `libs/shadcnui-signage/src/lib/behaviour/Countdown.tsx`
-- Registry JSON: `https://cambridgemonorail.github.io/WallRun/registry/registry.json`
+- Registry JSON: `https://wallrun.dev/registry/registry.json`
 
 ### Offline Fallback
 
 - Name: `offline-fallback`
 - Category: Behaviour
 - Purpose: fallback boundary for unhealthy or offline content.
-- Install: `npx shadcn@latest add https://cambridgemonorail.github.io/WallRun/registry/registry.json offline-fallback`
+- Install: `npx shadcn@latest add https://wallrun.dev/registry/offline-fallback.json`
 - Usage guidance: use around network-backed content where a stable degraded state matters.
 - Do not use for: static content with no health or connectivity state.
 - Dependencies: `clsx`, `tailwind-merge`
 - Source path: `libs/shadcnui-signage/src/lib/behaviour/OfflineFallback.tsx`
-- Registry JSON: `https://cambridgemonorail.github.io/WallRun/registry/registry.json`
+- Registry JSON: `https://wallrun.dev/registry/registry.json`
 
 ### Stale Data Indicator
 
 - Name: `stale-data-indicator`
 - Category: Behaviour
 - Purpose: freshness indicator when a feed exceeds an allowed age threshold.
-- Install: `npx shadcn@latest add https://cambridgemonorail.github.io/WallRun/registry/registry.json stale-data-indicator`
+- Install: `npx shadcn@latest add https://wallrun.dev/registry/stale-data-indicator.json`
 - Usage guidance: use beside live metrics, schedules, and operational feeds.
 - Do not use for: primary alert messaging; pair with more visible fallback UI when the whole screen is unhealthy.
 - Dependencies: `clsx`, `lucide-react`, `tailwind-merge`
 - Source path: `libs/shadcnui-signage/src/lib/behaviour/StaleDataIndicator.tsx`
-- Registry JSON: `https://cambridgemonorail.github.io/WallRun/registry/registry.json`
+- Registry JSON: `https://wallrun.dev/registry/registry.json`

--- a/apps/client/public/library.md
+++ b/apps/client/public/library.md
@@ -12,7 +12,7 @@ This markdown file is the machine-readable payload for the library overview.
 - `@wallrun/shadcnui`: WallRun's copy of shadcn/ui building-block primitives for general web UI.
 - `@wallrun/shadcnui-signage`: signage-oriented components for fixed-aspect layouts, distance readability, and always-on displays.
 - Storybook docs: interactive composition and usage examples hosted at `https://cambridgemonorail.github.io/WallRun/storybook/`.
-- Published registry: installable signage components at `https://cambridgemonorail.github.io/WallRun/registry/registry.json`.
+- Published registry index: installable signage components at `https://wallrun.dev/registry/registry.json`.
 
 ## When To Use Each Surface
 
@@ -27,13 +27,19 @@ WallRun signage components are distributed through the shadcn registry protocol.
 - Install one component:
 
 ```bash
-npx shadcn@latest add https://cambridgemonorail.github.io/WallRun/registry/registry.json clock
+npx shadcn@latest add https://wallrun.dev/registry/clock.json
 ```
 
 - Install several components:
 
 ```bash
-npx shadcn@latest add https://cambridgemonorail.github.io/WallRun/registry/registry.json metric-card event-card schedule-gate
+npx shadcn@latest add https://wallrun.dev/registry/metric-card.json https://wallrun.dev/registry/event-card.json https://wallrun.dev/registry/schedule-gate.json
+```
+
+- Install everything from the registry index:
+
+```bash
+npx shadcn@latest add https://wallrun.dev/registry/registry.json --all
 ```
 
 Registry installs copy component code into the consuming application. They are not version-locked runtime packages.
@@ -44,7 +50,7 @@ Registry installs copy component code into the consuming application. They are n
 - Human components route: `https://wallrun.dev/components`
 - Machine component catalogue: `https://wallrun.dev/components.md`
 - Project context: `https://wallrun.dev/ai-context.md`
-- Registry JSON: `https://cambridgemonorail.github.io/WallRun/registry/registry.json`
+- Registry JSON: `https://wallrun.dev/registry/registry.json`
 - Storybook docs: `https://cambridgemonorail.github.io/WallRun/storybook/?path=/docs/introduction--documentation`
 
 ## Hosting Note

--- a/apps/client/public/registry/README.md
+++ b/apps/client/public/registry/README.md
@@ -11,7 +11,7 @@ Add the registry to your `components.json`:
 ```json
 {
   "registries": {
-    "shadcnui-signage": "https://wallrun.dev/registry"
+    "@wallrun": "https://wallrun.dev/registry/{name}.json"
   }
 }
 ```
@@ -19,9 +19,15 @@ Add the registry to your `components.json`:
 Then install components:
 
 ```bash
-npx shadcn add shadcnui-signage/metric-card
-npx shadcn add shadcnui-signage/event-card
-npx shadcn add shadcnui-signage/signage-container
+npx shadcn add @wallrun/metric-card
+npx shadcn add @wallrun/event-card
+npx shadcn add @wallrun/signage-container
+```
+
+Install the whole registry only when you really want everything:
+
+```bash
+npx shadcn@latest add https://wallrun.dev/registry/registry.json --all
 ```
 
 ### Manual Installation

--- a/apps/client/public/registry/announcement-card.json
+++ b/apps/client/public/registry/announcement-card.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "announcement-card",
+  "type": "registry:component",
+  "title": "Announcement Card",
+  "description": "Display announcement information with title, description, date, icon, and category. Glass morphism effects for modern look.",
+  "registryDependencies": [],
+  "dependencies": [
+    "clsx",
+    "lucide-react",
+    "tailwind-merge"
+  ],
+  "files": [
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/primitives/AnnouncementCard.tsx",
+      "type": "registry:component"
+    },
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/utils/cn.ts",
+      "type": "registry:lib"
+    }
+  ]
+}

--- a/apps/client/public/registry/auto-paging-list.json
+++ b/apps/client/public/registry/auto-paging-list.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "auto-paging-list",
+  "type": "registry:component",
+  "title": "Auto Paging List",
+  "description": "Renders long lists as pages with automatic advancement. Perfect for scrolling-free displays with configurable dwell time per page.",
+  "registryDependencies": [],
+  "dependencies": [
+    "clsx",
+    "tailwind-merge"
+  ],
+  "files": [
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/behaviour/AutoPagingList.tsx",
+      "type": "registry:component"
+    },
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/hooks/useTicker.ts",
+      "type": "registry:lib"
+    },
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/hooks/usePrefersReducedMotion.ts",
+      "type": "registry:lib"
+    },
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/types/time.types.ts",
+      "type": "registry:lib"
+    },
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/utils/cn.ts",
+      "type": "registry:lib"
+    }
+  ]
+}

--- a/apps/client/public/registry/clock.json
+++ b/apps/client/public/registry/clock.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "clock",
+  "type": "registry:component",
+  "title": "Clock",
+  "description": "Displays current time with configurable format and timezone. Updates at minute boundaries for efficiency.",
+  "registryDependencies": [],
+  "dependencies": [
+    "clsx",
+    "tailwind-merge"
+  ],
+  "files": [
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/behaviour/Clock.tsx",
+      "type": "registry:component"
+    },
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/hooks/useTicker.ts",
+      "type": "registry:lib"
+    },
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/types/time.types.ts",
+      "type": "registry:lib"
+    },
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/utils/cn.ts",
+      "type": "registry:lib"
+    }
+  ]
+}

--- a/apps/client/public/registry/content-expired-warning.json
+++ b/apps/client/public/registry/content-expired-warning.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "content-expired-warning",
+  "type": "registry:component",
+  "title": "Content Expired Warning",
+  "description": "Highlights content that is beyond its approved display window with badge, panel, or overlay treatments.",
+  "registryDependencies": [],
+  "dependencies": [
+    "clsx",
+    "lucide-react",
+    "tailwind-merge"
+  ],
+  "files": [
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/behaviour/ContentExpiredWarning.tsx",
+      "type": "registry:component"
+    },
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/types/time.types.ts",
+      "type": "registry:lib"
+    },
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/utils/cn.ts",
+      "type": "registry:lib"
+    }
+  ]
+}

--- a/apps/client/public/registry/content-rotator.json
+++ b/apps/client/public/registry/content-rotator.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "content-rotator",
+  "type": "registry:component",
+  "title": "Content Rotator",
+  "description": "Cycles through children at fixed intervals with transitions. Supports pause/resume and dynamic content updates.",
+  "registryDependencies": [],
+  "dependencies": [
+    "clsx",
+    "tailwind-merge"
+  ],
+  "files": [
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/behaviour/ContentRotator.tsx",
+      "type": "registry:component"
+    },
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/behaviour/SignageTransition.tsx",
+      "type": "registry:component"
+    },
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/hooks/useTicker.ts",
+      "type": "registry:lib"
+    },
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/hooks/usePrefersReducedMotion.ts",
+      "type": "registry:lib"
+    },
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/types/time.types.ts",
+      "type": "registry:lib"
+    },
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/utils/cn.ts",
+      "type": "registry:lib"
+    }
+  ]
+}

--- a/apps/client/public/registry/countdown.json
+++ b/apps/client/public/registry/countdown.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "countdown",
+  "type": "registry:component",
+  "title": "Countdown",
+  "description": "Counts down to a target date/time with configurable format. When the target is reached, the timer stops at zero.",
+  "registryDependencies": [],
+  "dependencies": [
+    "clsx",
+    "tailwind-merge"
+  ],
+  "files": [
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/behaviour/Countdown.tsx",
+      "type": "registry:component"
+    },
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/hooks/useTicker.ts",
+      "type": "registry:lib"
+    },
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/types/time.types.ts",
+      "type": "registry:lib"
+    },
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/utils/cn.ts",
+      "type": "registry:lib"
+    }
+  ]
+}

--- a/apps/client/public/registry/directory-card.json
+++ b/apps/client/public/registry/directory-card.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "directory-card",
+  "type": "registry:component",
+  "title": "Directory Card",
+  "description": "Wayfinding card with department, floor, room, and contact metadata for directory and lobby signage.",
+  "registryDependencies": [],
+  "dependencies": [
+    "clsx",
+    "tailwind-merge"
+  ],
+  "files": [
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/primitives/DirectoryCard.tsx",
+      "type": "registry:component"
+    },
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/primitives/FloorBadge.tsx",
+      "type": "registry:component"
+    },
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/utils/cn.ts",
+      "type": "registry:lib"
+    }
+  ]
+}

--- a/apps/client/public/registry/event-card.json
+++ b/apps/client/public/registry/event-card.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "event-card",
+  "type": "registry:component",
+  "title": "Event Card",
+  "description": "Display event information with time, title, speaker, location, and track. Commonly used in event schedules and conference displays.",
+  "registryDependencies": [],
+  "dependencies": [
+    "clsx",
+    "lucide-react",
+    "tailwind-merge"
+  ],
+  "files": [
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/primitives/EventCard.tsx",
+      "type": "registry:component"
+    },
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/utils/cn.ts",
+      "type": "registry:lib"
+    }
+  ]
+}

--- a/apps/client/public/registry/floor-badge.json
+++ b/apps/client/public/registry/floor-badge.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "floor-badge",
+  "type": "registry:component",
+  "title": "Floor Badge",
+  "description": "Compact floor badge for wayfinding, room directories, and map overlays.",
+  "registryDependencies": [],
+  "dependencies": [
+    "clsx",
+    "tailwind-merge"
+  ],
+  "files": [
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/primitives/FloorBadge.tsx",
+      "type": "registry:component"
+    },
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/utils/cn.ts",
+      "type": "registry:lib"
+    }
+  ]
+}

--- a/apps/client/public/registry/fullscreen-hero.json
+++ b/apps/client/public/registry/fullscreen-hero.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "fullscreen-hero",
+  "type": "registry:component",
+  "title": "Fullscreen Hero",
+  "description": "Hero section for welcome screens and main messages. Light/dark variants with optional background images and CTA.",
+  "registryDependencies": [],
+  "dependencies": [
+    "clsx",
+    "tailwind-merge"
+  ],
+  "files": [
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/blocks/FullscreenHero.tsx",
+      "type": "registry:component"
+    },
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/utils/clamp.ts",
+      "type": "registry:lib"
+    },
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/utils/cn.ts",
+      "type": "registry:lib"
+    },
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/types/signage.types.ts",
+      "type": "registry:lib"
+    }
+  ]
+}

--- a/apps/client/public/registry/info-card-grid.json
+++ b/apps/client/public/registry/info-card-grid.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "info-card-grid",
+  "type": "registry:component",
+  "title": "Info Card Grid",
+  "description": "Grid layout for displaying informational cards with titles, values, descriptions, and optional meta text. Responsive column layout.",
+  "registryDependencies": [],
+  "dependencies": [
+    "clsx",
+    "tailwind-merge"
+  ],
+  "files": [
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/blocks/InfoCardGrid.tsx",
+      "type": "registry:component"
+    },
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/utils/clamp.ts",
+      "type": "registry:lib"
+    },
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/utils/cn.ts",
+      "type": "registry:lib"
+    },
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/utils/card.tsx",
+      "type": "registry:lib"
+    },
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/types/signage.types.ts",
+      "type": "registry:lib"
+    }
+  ]
+}

--- a/apps/client/public/registry/info-list.json
+++ b/apps/client/public/registry/info-list.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "info-list",
+  "type": "registry:component",
+  "title": "Info List",
+  "description": "Large-format list for lobby notices, visitor instructions, and operational status notes.",
+  "registryDependencies": [],
+  "dependencies": [
+    "clsx",
+    "tailwind-merge"
+  ],
+  "files": [
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/primitives/InfoList.tsx",
+      "type": "registry:component"
+    },
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/utils/cn.ts",
+      "type": "registry:lib"
+    }
+  ]
+}

--- a/apps/client/public/registry/last-updated-stamp.json
+++ b/apps/client/public/registry/last-updated-stamp.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "last-updated-stamp",
+  "type": "registry:component",
+  "title": "Last Updated Stamp",
+  "description": "Shows when a feed or message was last updated, with explicit stale-state handling for live-data screens.",
+  "registryDependencies": [],
+  "dependencies": [
+    "clsx",
+    "lucide-react",
+    "tailwind-merge"
+  ],
+  "files": [
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/behaviour/LastUpdatedStamp.tsx",
+      "type": "registry:component"
+    },
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/hooks/useTicker.ts",
+      "type": "registry:lib"
+    },
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/types/time.types.ts",
+      "type": "registry:lib"
+    },
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/utils/cn.ts",
+      "type": "registry:lib"
+    }
+  ]
+}

--- a/apps/client/public/registry/location-indicator.json
+++ b/apps/client/public/registry/location-indicator.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "location-indicator",
+  "type": "registry:component",
+  "title": "Location Indicator",
+  "description": "Current-location indicator with map pin iconography for wayfinding and directory signage.",
+  "registryDependencies": [],
+  "dependencies": [
+    "clsx",
+    "lucide-react",
+    "tailwind-merge"
+  ],
+  "files": [
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/primitives/LocationIndicator.tsx",
+      "type": "registry:component"
+    },
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/utils/cn.ts",
+      "type": "registry:lib"
+    }
+  ]
+}

--- a/apps/client/public/registry/meeting-row.json
+++ b/apps/client/public/registry/meeting-row.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "meeting-row",
+  "type": "registry:component",
+  "title": "Meeting Row",
+  "description": "Agenda-style row for schedules, room bookings, and office lobby meeting lists.",
+  "registryDependencies": [],
+  "dependencies": [
+    "clsx",
+    "tailwind-merge"
+  ],
+  "files": [
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/primitives/MeetingRow.tsx",
+      "type": "registry:component"
+    },
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/utils/cn.ts",
+      "type": "registry:lib"
+    }
+  ]
+}

--- a/apps/client/public/registry/menu-board.json
+++ b/apps/client/public/registry/menu-board.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "menu-board",
+  "type": "registry:component",
+  "title": "Menu Board",
+  "description": "Full-screen menu board shell with header, subtitle, and content region for restaurant and daypart signage.",
+  "registryDependencies": [],
+  "dependencies": [
+    "clsx",
+    "tailwind-merge"
+  ],
+  "files": [
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/blocks/MenuBoard.tsx",
+      "type": "registry:component"
+    },
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/layouts/SignageContainer.tsx",
+      "type": "registry:component"
+    },
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/utils/cn.ts",
+      "type": "registry:lib"
+    }
+  ]
+}

--- a/apps/client/public/registry/menu-item.json
+++ b/apps/client/public/registry/menu-item.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "menu-item",
+  "type": "registry:component",
+  "title": "Menu Item",
+  "description": "Menu row with item name, price, optional description, and signage-sized typography.",
+  "registryDependencies": [],
+  "dependencies": [
+    "clsx",
+    "tailwind-merge"
+  ],
+  "files": [
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/primitives/MenuItem.tsx",
+      "type": "registry:component"
+    },
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/utils/cn.ts",
+      "type": "registry:lib"
+    }
+  ]
+}

--- a/apps/client/public/registry/menu-section.json
+++ b/apps/client/public/registry/menu-section.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "menu-section",
+  "type": "registry:component",
+  "title": "Menu Section",
+  "description": "Section wrapper for grouped menu categories with headline and accent divider.",
+  "registryDependencies": [],
+  "dependencies": [
+    "clsx",
+    "tailwind-merge"
+  ],
+  "files": [
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/primitives/MenuSection.tsx",
+      "type": "registry:component"
+    },
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/utils/cn.ts",
+      "type": "registry:lib"
+    }
+  ]
+}

--- a/apps/client/public/registry/metric-card.json
+++ b/apps/client/public/registry/metric-card.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "metric-card",
+  "type": "registry:component",
+  "title": "Metric Card",
+  "description": "Display KPIs and metrics with values, change indicators, and icons. Optimized for distance readability on signage displays.",
+  "registryDependencies": [],
+  "dependencies": [
+    "clsx",
+    "lucide-react",
+    "tailwind-merge"
+  ],
+  "files": [
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/primitives/MetricCard.tsx",
+      "type": "registry:component"
+    },
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/utils/cn.ts",
+      "type": "registry:lib"
+    }
+  ]
+}

--- a/apps/client/public/registry/no-content-fallback.json
+++ b/apps/client/public/registry/no-content-fallback.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "no-content-fallback",
+  "type": "registry:component",
+  "title": "No Content Fallback",
+  "description": "Public-safe fallback surface for empty feeds and playlists, with optional operator metadata for debugging.",
+  "registryDependencies": [],
+  "dependencies": [
+    "clsx",
+    "lucide-react",
+    "tailwind-merge"
+  ],
+  "files": [
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/behaviour/NoContentFallback.tsx",
+      "type": "registry:component"
+    },
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/behaviour/LastUpdatedStamp.tsx",
+      "type": "registry:component"
+    },
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/hooks/useTicker.ts",
+      "type": "registry:lib"
+    },
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/types/time.types.ts",
+      "type": "registry:lib"
+    },
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/utils/cn.ts",
+      "type": "registry:lib"
+    }
+  ]
+}

--- a/apps/client/public/registry/offline-fallback.json
+++ b/apps/client/public/registry/offline-fallback.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "offline-fallback",
+  "type": "registry:component",
+  "title": "Offline Fallback",
+  "description": "Shows fallback UI when content is offline or unhealthy. Manual recovery control for graceful degradation.",
+  "registryDependencies": [],
+  "dependencies": [
+    "clsx",
+    "tailwind-merge"
+  ],
+  "files": [
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/behaviour/OfflineFallback.tsx",
+      "type": "registry:component"
+    },
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/utils/cn.ts",
+      "type": "registry:lib"
+    }
+  ]
+}

--- a/apps/client/public/registry/one-message-frame.json
+++ b/apps/client/public/registry/one-message-frame.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "one-message-frame",
+  "type": "registry:component",
+  "title": "One Message Frame",
+  "description": "Opinionated signage shell for one dominant message, one supporting context line, and one clear next step.",
+  "registryDependencies": [],
+  "dependencies": [
+    "clsx",
+    "tailwind-merge"
+  ],
+  "files": [
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/blocks/OneMessageFrame.tsx",
+      "type": "registry:component"
+    },
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/utils/clamp.ts",
+      "type": "registry:lib"
+    },
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/utils/cn.ts",
+      "type": "registry:lib"
+    },
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/types/signage.types.ts",
+      "type": "registry:lib"
+    }
+  ]
+}

--- a/apps/client/public/registry/reconnecting-state.json
+++ b/apps/client/public/registry/reconnecting-state.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "reconnecting-state",
+  "type": "registry:component",
+  "title": "Reconnecting State",
+  "description": "Operator-facing reconnecting state for live content, with inline and panel variants and last-live metadata.",
+  "registryDependencies": [],
+  "dependencies": [
+    "clsx",
+    "lucide-react",
+    "tailwind-merge"
+  ],
+  "files": [
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/behaviour/ReconnectingState.tsx",
+      "type": "registry:component"
+    },
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/types/time.types.ts",
+      "type": "registry:lib"
+    },
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/utils/cn.ts",
+      "type": "registry:lib"
+    }
+  ]
+}

--- a/apps/client/public/registry/registry.json
+++ b/apps/client/public/registry/registry.json
@@ -309,6 +309,32 @@
       ]
     },
     {
+      "name": "one-message-frame",
+      "type": "registry:component",
+      "title": "One Message Frame",
+      "description": "Opinionated signage shell for one dominant message, one supporting context line, and one clear next step.",
+      "registryDependencies": [],
+      "dependencies": ["clsx", "tailwind-merge"],
+      "files": [
+        {
+          "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/blocks/OneMessageFrame.tsx",
+          "type": "registry:component"
+        },
+        {
+          "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/utils/clamp.ts",
+          "type": "registry:lib"
+        },
+        {
+          "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/utils/cn.ts",
+          "type": "registry:lib"
+        },
+        {
+          "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/types/signage.types.ts",
+          "type": "registry:lib"
+        }
+      ]
+    },
+    {
       "name": "info-card-grid",
       "type": "registry:component",
       "title": "Info Card Grid",
@@ -535,6 +561,106 @@
         {
           "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/behaviour/OfflineFallback.tsx",
           "type": "registry:component"
+        },
+        {
+          "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/utils/cn.ts",
+          "type": "registry:lib"
+        }
+      ]
+    },
+    {
+      "name": "no-content-fallback",
+      "type": "registry:component",
+      "title": "No Content Fallback",
+      "description": "Public-safe fallback surface for empty feeds and playlists, with optional operator metadata for debugging.",
+      "registryDependencies": [],
+      "dependencies": ["clsx", "lucide-react", "tailwind-merge"],
+      "files": [
+        {
+          "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/behaviour/NoContentFallback.tsx",
+          "type": "registry:component"
+        },
+        {
+          "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/behaviour/LastUpdatedStamp.tsx",
+          "type": "registry:component"
+        },
+        {
+          "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/hooks/useTicker.ts",
+          "type": "registry:lib"
+        },
+        {
+          "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/types/time.types.ts",
+          "type": "registry:lib"
+        },
+        {
+          "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/utils/cn.ts",
+          "type": "registry:lib"
+        }
+      ]
+    },
+    {
+      "name": "content-expired-warning",
+      "type": "registry:component",
+      "title": "Content Expired Warning",
+      "description": "Highlights content that is beyond its approved display window with badge, panel, or overlay treatments.",
+      "registryDependencies": [],
+      "dependencies": ["clsx", "lucide-react", "tailwind-merge"],
+      "files": [
+        {
+          "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/behaviour/ContentExpiredWarning.tsx",
+          "type": "registry:component"
+        },
+        {
+          "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/types/time.types.ts",
+          "type": "registry:lib"
+        },
+        {
+          "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/utils/cn.ts",
+          "type": "registry:lib"
+        }
+      ]
+    },
+    {
+      "name": "last-updated-stamp",
+      "type": "registry:component",
+      "title": "Last Updated Stamp",
+      "description": "Shows when a feed or message was last updated, with explicit stale-state handling for live-data screens.",
+      "registryDependencies": [],
+      "dependencies": ["clsx", "lucide-react", "tailwind-merge"],
+      "files": [
+        {
+          "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/behaviour/LastUpdatedStamp.tsx",
+          "type": "registry:component"
+        },
+        {
+          "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/hooks/useTicker.ts",
+          "type": "registry:lib"
+        },
+        {
+          "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/types/time.types.ts",
+          "type": "registry:lib"
+        },
+        {
+          "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/utils/cn.ts",
+          "type": "registry:lib"
+        }
+      ]
+    },
+    {
+      "name": "reconnecting-state",
+      "type": "registry:component",
+      "title": "Reconnecting State",
+      "description": "Operator-facing reconnecting state for live content, with inline and panel variants and last-live metadata.",
+      "registryDependencies": [],
+      "dependencies": ["clsx", "lucide-react", "tailwind-merge"],
+      "files": [
+        {
+          "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/behaviour/ReconnectingState.tsx",
+          "type": "registry:component"
+        },
+        {
+          "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/types/time.types.ts",
+          "type": "registry:lib"
         },
         {
           "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/utils/cn.ts",

--- a/apps/client/public/registry/schedule-gate.json
+++ b/apps/client/public/registry/schedule-gate.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "schedule-gate",
+  "type": "registry:component",
+  "title": "Schedule Gate",
+  "description": "Conditionally renders content based on weekday and time windows. Supports timezone-aware scheduling for daypart menus and time-based content.",
+  "registryDependencies": [],
+  "dependencies": [
+    "clsx",
+    "date-fns-tz",
+    "tailwind-merge"
+  ],
+  "files": [
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/behaviour/ScheduleGate.tsx",
+      "type": "registry:component"
+    },
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/hooks/useTicker.ts",
+      "type": "registry:lib"
+    },
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/types/time.types.ts",
+      "type": "registry:lib"
+    },
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/utils/cn.ts",
+      "type": "registry:lib"
+    }
+  ]
+}

--- a/apps/client/public/registry/screen-frame.json
+++ b/apps/client/public/registry/screen-frame.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "screen-frame",
+  "type": "registry:component",
+  "title": "Screen Frame",
+  "description": "Preview container with aspect ratio enforcement and safe area guides. Useful for development and QA testing.",
+  "registryDependencies": [],
+  "dependencies": [],
+  "files": [
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/primitives/ScreenFrame.tsx",
+      "type": "registry:component"
+    },
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/utils/resolution.ts",
+      "type": "registry:lib"
+    },
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/types/signage.types.ts",
+      "type": "registry:lib"
+    }
+  ]
+}

--- a/apps/client/public/registry/signage-container.json
+++ b/apps/client/public/registry/signage-container.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "signage-container",
+  "type": "registry:component",
+  "title": "Signage Container",
+  "description": "Full-screen container with gradient backgrounds, ambient orb effects, and optional grid overlay. 8 color variants available.",
+  "registryDependencies": [],
+  "dependencies": [
+    "clsx",
+    "tailwind-merge"
+  ],
+  "files": [
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/layouts/SignageContainer.tsx",
+      "type": "registry:component"
+    },
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/utils/cn.ts",
+      "type": "registry:lib"
+    }
+  ]
+}

--- a/apps/client/public/registry/signage-header.json
+++ b/apps/client/public/registry/signage-header.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "signage-header",
+  "type": "registry:component",
+  "title": "Signage Header",
+  "description": "Standard signage header with optional tag badge, title, and subtitle. Multiple color variants and alignment options.",
+  "registryDependencies": [],
+  "dependencies": [
+    "clsx",
+    "tailwind-merge"
+  ],
+  "files": [
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/layouts/SignageHeader.tsx",
+      "type": "registry:component"
+    },
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/utils/cn.ts",
+      "type": "registry:lib"
+    }
+  ]
+}

--- a/apps/client/public/registry/signage-panel.json
+++ b/apps/client/public/registry/signage-panel.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "signage-panel",
+  "type": "registry:component",
+  "title": "Signage Panel",
+  "description": "Bordered content panel for grouped supporting information on lobby and operational screens.",
+  "registryDependencies": [],
+  "dependencies": [
+    "clsx",
+    "tailwind-merge"
+  ],
+  "files": [
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/primitives/SignagePanel.tsx",
+      "type": "registry:component"
+    },
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/utils/cn.ts",
+      "type": "registry:lib"
+    }
+  ]
+}

--- a/apps/client/public/registry/signage-transition.json
+++ b/apps/client/public/registry/signage-transition.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "signage-transition",
+  "type": "registry:component",
+  "title": "Signage Transition",
+  "description": "Wraps a single child with signage-appropriate transitions (crossfade, slide). Respects prefers-reduced-motion.",
+  "registryDependencies": [],
+  "dependencies": [
+    "clsx",
+    "tailwind-merge"
+  ],
+  "files": [
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/behaviour/SignageTransition.tsx",
+      "type": "registry:component"
+    },
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/hooks/usePrefersReducedMotion.ts",
+      "type": "registry:lib"
+    },
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/utils/cn.ts",
+      "type": "registry:lib"
+    }
+  ]
+}

--- a/apps/client/public/registry/split-screen.json
+++ b/apps/client/public/registry/split-screen.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "split-screen",
+  "type": "registry:component",
+  "title": "Split Screen",
+  "description": "Two-panel layout with configurable ratio and direction. Perfect for showing multiple content streams side-by-side.",
+  "registryDependencies": [],
+  "dependencies": [
+    "clsx",
+    "tailwind-merge"
+  ],
+  "files": [
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/layouts/SplitScreen.tsx",
+      "type": "registry:component"
+    },
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/types/signage.types.ts",
+      "type": "registry:lib"
+    }
+  ]
+}

--- a/apps/client/public/registry/stale-data-indicator.json
+++ b/apps/client/public/registry/stale-data-indicator.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "stale-data-indicator",
+  "type": "registry:component",
+  "title": "Stale Data Indicator",
+  "description": "Shows visual indicator when data exceeds a freshness threshold. Useful for monitoring real-time data feeds.",
+  "registryDependencies": [],
+  "dependencies": [
+    "clsx",
+    "lucide-react",
+    "tailwind-merge"
+  ],
+  "files": [
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/behaviour/StaleDataIndicator.tsx",
+      "type": "registry:component"
+    },
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/hooks/useTicker.ts",
+      "type": "registry:lib"
+    },
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/types/time.types.ts",
+      "type": "registry:lib"
+    },
+    {
+      "path": "https://raw.githubusercontent.com/CambridgeMonorail/WallRun/main/libs/shadcnui-signage/src/lib/utils/cn.ts",
+      "type": "registry:lib"
+    }
+  ]
+}

--- a/apps/client/src/app/components/CodeSnippet.test.tsx
+++ b/apps/client/src/app/components/CodeSnippet.test.tsx
@@ -93,6 +93,19 @@ export const App = () => <Button>Click me</Button>;`;
     ).toBeInTheDocument();
   });
 
+  it('preserves values for flags that consume the next argument', () => {
+    const legacyRegistryCode =
+      `npx shadcn@latest add ${LEGACY_REGISTRY_URL} metric-card --path components/signage --cwd apps/client`;
+
+    render(<CodeSnippet code={legacyRegistryCode} language="bash" />);
+
+    expect(
+      screen.getByText(
+        `npx shadcn@latest add ${getPublicRegistryItemUrl('metric-card')} --path components/signage --cwd apps/client`,
+      ),
+    ).toBeInTheDocument();
+  });
+
   it('shows "Copied" message after successful copy', async () => {
     render(<CodeSnippet code={sampleCode} />);
 

--- a/apps/client/src/app/components/CodeSnippet.test.tsx
+++ b/apps/client/src/app/components/CodeSnippet.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
 import { CodeSnippet } from './CodeSnippet';
 import {
+  getPublicRegistryItemUrl,
   LEGACY_REGISTRY_URL,
   PUBLIC_REGISTRY_URL,
 } from './componentDocs.constants';
@@ -47,7 +48,11 @@ export const App = () => <Button>Click me</Button>;`;
 
     render(<CodeSnippet code={legacyRegistryCode} language="bash" />);
 
-    expect(screen.getByText(`npx shadcn@latest add ${PUBLIC_REGISTRY_URL} menu-board`)).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        `npx shadcn@latest add ${getPublicRegistryItemUrl('menu-board')}`,
+      ),
+    ).toBeInTheDocument();
     expect(screen.queryByText(legacyRegistryCode)).not.toBeInTheDocument();
   });
 
@@ -60,9 +65,32 @@ export const App = () => <Button>Click me</Button>;`;
 
     await waitFor(() => {
       expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
-        `npx shadcn@latest add ${PUBLIC_REGISTRY_URL} menu-board`,
+        `npx shadcn@latest add ${getPublicRegistryItemUrl('menu-board')}`,
       );
     });
+  });
+
+  it('rewrites multi-item registry installs to per-item URLs', () => {
+    const legacyRegistryCode =
+      `npx shadcn@latest add ${LEGACY_REGISTRY_URL} metric-card event-card schedule-gate`;
+
+    render(<CodeSnippet code={legacyRegistryCode} language="bash" />);
+
+    expect(
+      screen.getByText(
+        `npx shadcn@latest add ${getPublicRegistryItemUrl('metric-card')} ${getPublicRegistryItemUrl('event-card')} ${getPublicRegistryItemUrl('schedule-gate')}`,
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('keeps the root registry index for --all installs', () => {
+    const rootRegistryCode = `npx shadcn@latest add ${LEGACY_REGISTRY_URL} --all`;
+
+    render(<CodeSnippet code={rootRegistryCode} language="bash" />);
+
+    expect(
+      screen.getByText(`npx shadcn@latest add ${PUBLIC_REGISTRY_URL} --all`),
+    ).toBeInTheDocument();
   });
 
   it('shows "Copied" message after successful copy', async () => {

--- a/apps/client/src/app/components/CodeSnippet.tsx
+++ b/apps/client/src/app/components/CodeSnippet.tsx
@@ -3,9 +3,41 @@ import { Button } from '@wallrun/shadcnui';
 import { Check, Copy } from 'lucide-react';
 import { cn } from '@wallrun/shadcnui';
 import {
+  getPublicRegistryItemUrl,
   LEGACY_REGISTRY_URL,
   PUBLIC_REGISTRY_URL,
 } from './componentDocs.constants';
+
+const REGISTRY_COMMAND_PREFIX = 'npx shadcn@latest add ';
+
+const escapeRegExp = (value: string) =>
+  value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const rewriteRegistryCommand = (code: string, registryUrl: string) => {
+  const commandPattern = new RegExp(
+    `${escapeRegExp(REGISTRY_COMMAND_PREFIX)}${escapeRegExp(registryUrl)}\\s+([^\\n]+)`,
+    'g',
+  );
+
+  return code.replace(commandPattern, (_match, rawArguments: string) => {
+    const tokens = rawArguments.trim().split(/\s+/u);
+    const containsNamedItems = tokens.some((token) => !token.startsWith('-'));
+
+    if (!containsNamedItems) {
+      return `${REGISTRY_COMMAND_PREFIX}${PUBLIC_REGISTRY_URL} ${tokens.join(' ')}`.trim();
+    }
+
+    const rewrittenTokens = tokens.map((token) => {
+      if (token.startsWith('-')) {
+        return token;
+      }
+
+      return getPublicRegistryItemUrl(token);
+    });
+
+    return `${REGISTRY_COMMAND_PREFIX}${rewrittenTokens.join(' ')}`;
+  });
+};
 
 export interface CodeSnippetProps {
   /**
@@ -58,7 +90,10 @@ export const CodeSnippet: FC<CodeSnippetProps> = ({
   'data-testid': dataTestId = 'code-snippet',
 }) => {
   const [copied, setCopied] = useState(false);
-  const displayedCode = code.split(LEGACY_REGISTRY_URL).join(PUBLIC_REGISTRY_URL);
+  const displayedCode = [LEGACY_REGISTRY_URL, PUBLIC_REGISTRY_URL].reduce(
+    (currentCode, registryUrl) => rewriteRegistryCommand(currentCode, registryUrl),
+    code,
+  );
 
   const handleCopy = async () => {
     try {

--- a/apps/client/src/app/components/CodeSnippet.tsx
+++ b/apps/client/src/app/components/CodeSnippet.tsx
@@ -9,6 +9,7 @@ import {
 } from './componentDocs.constants';
 
 const REGISTRY_COMMAND_PREFIX = 'npx shadcn@latest add ';
+const REGISTRY_FLAGS_WITH_VALUES = new Set(['-c', '--cwd', '-p', '--path']);
 
 const escapeRegExp = (value: string) =>
   value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -21,19 +22,34 @@ const rewriteRegistryCommand = (code: string, registryUrl: string) => {
 
   return code.replace(commandPattern, (_match, rawArguments: string) => {
     const tokens = rawArguments.trim().split(/\s+/u);
-    const containsNamedItems = tokens.some((token) => !token.startsWith('-'));
+    const rewrittenTokens: string[] = [];
+    let containsNamedItems = false;
+    let expectsFlagValue = false;
+
+    for (const token of tokens) {
+      if (expectsFlagValue) {
+        rewrittenTokens.push(token);
+        expectsFlagValue = false;
+        continue;
+      }
+
+      if (token.startsWith('-')) {
+        rewrittenTokens.push(token);
+
+        if (REGISTRY_FLAGS_WITH_VALUES.has(token)) {
+          expectsFlagValue = true;
+        }
+
+        continue;
+      }
+
+      containsNamedItems = true;
+      rewrittenTokens.push(getPublicRegistryItemUrl(token));
+    }
 
     if (!containsNamedItems) {
       return `${REGISTRY_COMMAND_PREFIX}${PUBLIC_REGISTRY_URL} ${tokens.join(' ')}`.trim();
     }
-
-    const rewrittenTokens = tokens.map((token) => {
-      if (token.startsWith('-')) {
-        return token;
-      }
-
-      return getPublicRegistryItemUrl(token);
-    });
 
     return `${REGISTRY_COMMAND_PREFIX}${rewrittenTokens.join(' ')}`;
   });

--- a/apps/client/src/app/components/ComponentDocTemplate.tsx
+++ b/apps/client/src/app/components/ComponentDocTemplate.tsx
@@ -1,7 +1,7 @@
 import { FC, ReactNode } from 'react';
 import { Button } from '@wallrun/shadcnui';
 import { CodeSnippet } from './CodeSnippet';
-import { PUBLIC_REGISTRY_URL } from './componentDocs.constants';
+import { getPublicRegistryItemUrl } from './componentDocs.constants';
 
 type ComponentDocLink = {
   label: string;
@@ -90,7 +90,7 @@ export const ComponentDocTemplate: FC<ComponentDocTemplateProps> = ({
           <h3 className="mb-3 text-lg font-medium">Using the CLI (Recommended)</h3>
           <CodeSnippet
             language="bash"
-            code={`npx shadcn@latest add ${PUBLIC_REGISTRY_URL} ${installName}`}
+            code={`npx shadcn@latest add ${getPublicRegistryItemUrl(installName)}`}
           />
         </div>
 

--- a/apps/client/src/app/components/componentDocs.constants.ts
+++ b/apps/client/src/app/components/componentDocs.constants.ts
@@ -1,5 +1,10 @@
 export const PUBLIC_REGISTRY_URL =
   'https://wallrun.dev/registry/registry.json';
 
+export const PUBLIC_REGISTRY_BASE_URL = 'https://wallrun.dev/registry';
+
 export const LEGACY_REGISTRY_URL =
   'https://cambridgemonorail.github.io/WallRun/registry/registry.json';
+
+export const getPublicRegistryItemUrl = (name: string) =>
+  `${PUBLIC_REGISTRY_BASE_URL}/${name}.json`;

--- a/apps/client/src/app/pages/getting-started/GettingStarted.tsx
+++ b/apps/client/src/app/pages/getting-started/GettingStarted.tsx
@@ -152,10 +152,10 @@ export const GettingStartedPage: FC = () => {
             <div className="code-panel overflow-x-auto p-4 font-mono text-sm text-foreground">
               <pre>
                 {`# Add individual components from WallRun registry
-npx shadcn@latest add https://cambridgemonorail.github.io/WallRun/registry/registry.json auto-paging-list
+npx shadcn@latest add https://wallrun.dev/registry/auto-paging-list.json
 
 # Add several at once
-npx shadcn@latest add https://cambridgemonorail.github.io/WallRun/registry/registry.json metric-card event-card schedule-gate`}
+npx shadcn@latest add https://wallrun.dev/registry/metric-card.json https://wallrun.dev/registry/event-card.json https://wallrun.dev/registry/schedule-gate.json`}
               </pre>
             </div>
             <p className="text-muted-foreground mt-2 text-sm">

--- a/apps/client/src/app/pages/home/Home.tsx
+++ b/apps/client/src/app/pages/home/Home.tsx
@@ -180,7 +180,7 @@ export const Home: FC = () => {
               </div>
             </div>
             <div className="code-panel mb-3 overflow-x-auto p-3 font-mono text-xs text-foreground">
-              <pre>{`npx shadcn@latest add https://cambridgemonorail.github.io/WallRun/registry/registry.json auto-paging-list`}</pre>
+              <pre>{`npx shadcn@latest add https://wallrun.dev/registry/auto-paging-list.json`}</pre>
             </div>
             <Button asChild variant="secondary">
               <Link to="/getting-started">See install options</Link>

--- a/apps/client/src/app/pages/library/Library.tsx
+++ b/apps/client/src/app/pages/library/Library.tsx
@@ -129,13 +129,13 @@ export function LibraryPage() {
             <pre>
               {`# Install a single signage component
 npx shadcn@latest add \\
-  https://cambridgemonorail.github.io/WallRun/registry/registry.json \\
-  clock
+  https://wallrun.dev/registry/clock.json
 
 # Install multiple components
 npx shadcn@latest add \\
-  https://cambridgemonorail.github.io/WallRun/registry/registry.json \\
-  metric-card event-card schedule-gate`}
+  https://wallrun.dev/registry/metric-card.json \
+  https://wallrun.dev/registry/event-card.json \
+  https://wallrun.dev/registry/schedule-gate.json`}
             </pre>
           </div>
           <p>

--- a/docs/guides/registry-maintenance.md
+++ b/docs/guides/registry-maintenance.md
@@ -6,30 +6,33 @@ WallRun publishes a shadcn-compatible registry from the checked-in file `apps/cl
 
 - Public registry URL: `https://wallrun.dev/registry/registry.json`
 - Source of truth in the repo: `apps/client/public/registry/registry.json`
+- Generated item URLs: `https://wallrun.dev/registry/<item-name>.json`
 - Source files referenced by registry items: `libs/shadcnui-signage/src/lib/**`
 
 This guide is for maintainers updating the published registry, not end users installing from it.
 
 ## How WallRun's Registry Works
 
-WallRun does **not** currently generate registry artifacts with `shadcn build` or an equivalent repo wrapper.
-
-Instead, the registry is maintained as a static, checked-in JSON file that is shipped with the client app's public assets.
+WallRun does not use `shadcn build`, but it does generate checked-in per-item registry artifacts from the static root index.
 
 That means the maintainer workflow today is:
 
 1. edit or add the source component files in `libs/shadcnui-signage`
 2. update the matching entry in `apps/client/public/registry/registry.json`
-3. verify the public registry still describes the component accurately
-4. ship the change through the normal repo workflow so the static client deploy publishes the updated JSON
+3. run `pnpm sync:registry` to regenerate `apps/client/public/registry/*.json`
+4. verify the public registry still describes the component accurately
+5. ship the change through the normal repo workflow so the static client deploy publishes the updated JSON
 
-Each registry item points to raw GitHub file URLs for the files that the shadcn CLI should copy into downstream projects. The public registry index itself is served from `wallrun.dev`, but the `files[].path` entries currently resolve to raw GitHub content on `main`.
+The root `registry.json` remains the entry point for discovery and `--all` installs. Individual installs should use the generated item files such as `https://wallrun.dev/registry/menu-board.json`.
+
+Each registry item points to raw GitHub file URLs for the files that the shadcn CLI should copy into downstream projects. The public registry index and generated item files are served from `wallrun.dev`, but the `files[].path` entries currently resolve to raw GitHub content on `main`.
 
 ## Maintainer Entry Points
 
 When working on the registry, treat these files as the main control surfaces:
 
 - `apps/client/public/registry/registry.json` - published registry definition
+- `apps/client/public/registry/*.json` - generated item entry points committed with the app
 - `apps/client/public/registry/README.md` - consumer-facing install notes
 - `libs/shadcnui-signage/src/index.ts` - public export surface to keep in sync with intended registry coverage
 - `libs/shadcnui-signage/src/lib/**` - actual source files referenced by registry items
@@ -176,10 +179,16 @@ Before merging a registry update, confirm all of the following:
 When you update examples in docs, prefer the canonical public registry URL:
 
 ```bash
-npx shadcn@latest add https://wallrun.dev/registry/registry.json component-name
+npx shadcn@latest add https://wallrun.dev/registry/component-name.json
 ```
 
-That keeps documentation aligned with the deployed registry entry point rather than the older GitHub Pages host.
+Use the root index only for discovery and `--all` installs:
+
+```bash
+npx shadcn@latest add https://wallrun.dev/registry/registry.json --all
+```
+
+That keeps documentation aligned with the deployed registry entry point rather than the older GitHub Pages host while still using valid item installs.
 
 ## Maintenance Schedule
 

--- a/docs/new features/wallrun-signage-component-gaps-spec.md
+++ b/docs/new features/wallrun-signage-component-gaps-spec.md
@@ -1,0 +1,903 @@
+# WallRun Signage Component Gaps Spec
+
+## Purpose
+
+This spec turns the component gap review into an implementation brief for expanding WallRun's signage component library.
+
+WallRun already has useful signage primitives, layouts, blocks, and behaviours. The next layer should help creators build complete signage systems: playlists, screen-role templates, calls to action, live data states, operational fallbacks, physical screen validation, and governed publishing patterns.
+
+The goal is not to copy a CMS feature list. The goal is to add React components that make signage-specific decisions explicit in code.
+
+## Current Baseline
+
+The existing signage library already covers:
+
+- fixed-format framing: `ScreenFrame`
+- layout shells: `SignageContainer`, `SplitScreen`, `SignageHeader`
+- content primitives: `MetricCard`, `EventCard`, `AnnouncementCard`, `DirectoryCard`, `FloorBadge`, `LocationIndicator`, `MenuItem`, `MenuSection`, `SignagePanel`, `MeetingRow`, `InfoList`
+- composed blocks: `FullscreenHero`, `InfoCardGrid`, `MenuBoard`
+- runtime behaviours: `Clock`, `Countdown`, `ContentRotator`, `AutoPagingList`, `ScheduleGate`, `StaleDataIndicator`, `SignageTransition`, `OfflineFallback`
+
+The missing layer is not more generic UI. It is signage-native workflow support.
+
+## Design Principles
+
+- Treat signage as a timed surface, not a web page.
+- Make screen role, dwell context, and schedule explicit.
+- Prefer one dominant message with subordinate support.
+- Make CTA, QR, freshness, and expiry states hard to forget.
+- Support real display constraints: portrait, overscan, bezels, reach zones, and viewing distance.
+- Components should be deterministic at known resolutions.
+- Components should ship with Storybook examples, registry entries, and tests.
+
+## Priority Roadmap
+
+### Phase 1: Core Runtime and Message Clarity
+
+Build these first because they affect almost every signage project.
+
+- `PlaylistTimeline`
+- `PlaylistItem`
+- `LoopProgress`
+- `PriorityTakeover`
+- `QRCodeCallout`
+- `ShortUrlCallout`
+- `ActionStrip`
+- `OneMessageFrame`
+- `NoContentFallback`
+- `ContentExpiredWarning`
+- `LastUpdatedStamp`
+
+### Phase 2: Creator Starting Points
+
+Build these once the runtime primitives exist.
+
+- `ArrivalBoard`
+- `WayfindingBoard`
+- `WaitingRoomBoard`
+- `DecisionBoard`
+- `OperationalStatusBoard`
+- `WorkplaceShiftBoard`
+- `RestaurantMenuBoard`
+- `EventScheduleBoard`
+
+### Phase 3: Real-Screen QA and Operations
+
+Build these to support deployment confidence and production review.
+
+- `BezelGrid`
+- `OverscanGuide`
+- `ReachZoneOverlay`
+- `ViewingDistancePreview`
+- `OrientationSwitcher`
+- `PlayerHealthPanel`
+- `DeploymentVersionBadge`
+- `ReconnectingState`
+
+### Phase 4: Interactive and Governance Patterns
+
+Build these after the static and timed-signage path is solid.
+
+- `KioskHome`
+- `TouchNav`
+- `IdleReset`
+- `BackHomeControls`
+- `QRHandoff`
+- `MessageApprovalBadge`
+- `ContentOwnerLabel`
+- `ExpiryDateBadge`
+- `LocalOverrideSlot`
+
+## Component Specs
+
+### PlaylistTimeline
+
+Purpose: visualize and drive a signage loop with explicit durations, priorities, and current item state.
+
+Recommended API:
+
+```ts
+type PlaylistTimelineProps = {
+  items: Array<{
+    id: string
+    label: string
+    durationMs: number
+    priority?: 'normal' | 'important' | 'takeover'
+    startsAt?: Date | string
+    endsAt?: Date | string
+  }>
+  activeId?: string
+  showDurations?: boolean
+  variant?: 'compact' | 'full'
+}
+```
+
+Acceptance criteria:
+
+- clearly shows what is live now and what is next
+- supports short loops without visual clutter
+- marks expired or future items distinctly
+- uses tabular timing where durations are visible
+- has Storybook stories for announcement loop, menu dayparts, and emergency takeover
+
+### PlaylistItem
+
+Purpose: wrap one timed piece of signage content with duration, priority, and metadata.
+
+Recommended API:
+
+```ts
+type PlaylistItemProps = {
+  durationMs: number
+  priority?: 'normal' | 'important' | 'takeover'
+  label?: string
+  children: React.ReactNode
+}
+```
+
+Acceptance criteria:
+
+- works with `ContentRotator` or a future playlist controller
+- exposes metadata without forcing visible chrome
+- supports testable duration values
+
+### LoopProgress
+
+Purpose: provide a subtle progress cue for the current loop or current item.
+
+Recommended API:
+
+```ts
+type LoopProgressProps = {
+  value: number
+  max?: number
+  label?: string
+  position?: 'top' | 'bottom' | 'inline'
+  tone?: 'subtle' | 'visible'
+}
+```
+
+Acceptance criteria:
+
+- does not compete with the main message
+- can be hidden from final production screens when used only for preview
+- supports reduced-motion preferences
+
+### PriorityTakeover
+
+Purpose: temporarily override the normal loop for urgent, operational, or event-critical content.
+
+Recommended API:
+
+```ts
+type PriorityTakeoverProps = {
+  active: boolean
+  reason?: string
+  tone?: 'urgent' | 'service' | 'maintenance' | 'neutral'
+  children: React.ReactNode
+  fallback?: React.ReactNode
+}
+```
+
+Acceptance criteria:
+
+- takeover content is visually unmistakable
+- normal fallback content remains available
+- supports emergency, delay, closure, and maintenance examples
+
+### QRCodeCallout
+
+Purpose: show a scan-safe QR code with a clear instruction and destination label.
+
+Recommended API:
+
+```ts
+type QRCodeCalloutProps = {
+  value: string
+  label: string
+  instruction?: string
+  shortUrl?: string
+  size?: 'sm' | 'md' | 'lg'
+  errorCorrectionLevel?: 'L' | 'M' | 'Q' | 'H'
+}
+```
+
+Acceptance criteria:
+
+- QR code stays large enough for common viewing distances
+- destination text is visible so the action is not mysterious
+- supports light and dark backgrounds
+- includes a story for poster-style CTA and side-zone CTA
+
+### ShortUrlCallout
+
+Purpose: provide a non-QR fallback for calls to action.
+
+Recommended API:
+
+```ts
+type ShortUrlCalloutProps = {
+  url: string
+  label?: string
+  prefix?: string
+  variant?: 'inline' | 'panel' | 'strip'
+}
+```
+
+Acceptance criteria:
+
+- URL is readable from distance
+- optional label explains the destination
+- pairs cleanly with `QRCodeCallout`
+
+### ActionStrip
+
+Purpose: reserve a clear CTA area without overloading the primary message.
+
+Recommended API:
+
+```ts
+type ActionStripProps = {
+  message: string
+  action?: React.ReactNode
+  position?: 'bottom' | 'right' | 'left'
+  tone?: 'brand' | 'neutral' | 'urgent'
+}
+```
+
+Acceptance criteria:
+
+- keeps one primary action visually dominant
+- does not shrink the main content below legibility thresholds
+- works in landscape and portrait examples
+
+### OneMessageFrame
+
+Purpose: enforce the "one main point, one next step" signage pattern.
+
+Recommended API:
+
+```ts
+type OneMessageFrameProps = {
+  headline: string
+  supportingText?: string
+  action?: React.ReactNode
+  media?: React.ReactNode
+  utility?: React.ReactNode
+}
+```
+
+Acceptance criteria:
+
+- headline remains the dominant element
+- supporting text clamps to a safe line count
+- action area is optional but visually clear when present
+
+### NoContentFallback
+
+Purpose: prevent blank screens when a playlist, feed, or schedule has nothing valid to show.
+
+Recommended API:
+
+```ts
+type NoContentFallbackProps = {
+  title?: string
+  message?: string
+  owner?: string
+  lastCheckedAt?: Date | string
+  variant?: 'public-safe' | 'operator-debug'
+}
+```
+
+Acceptance criteria:
+
+- public-safe mode avoids exposing technical internals
+- operator-debug mode can show enough information for diagnosis
+- works with `OfflineFallback` and `StaleDataIndicator`
+
+### ContentExpiredWarning
+
+Purpose: mark content that is beyond its scheduled or approved display window.
+
+Recommended API:
+
+```ts
+type ContentExpiredWarningProps = {
+  expiredAt: Date | string
+  label?: string
+  variant?: 'badge' | 'panel' | 'overlay'
+}
+```
+
+Acceptance criteria:
+
+- badge mode is suitable for admin preview
+- overlay mode is suitable for QA, not public playback by default
+- pairs with governed content metadata
+
+### LastUpdatedStamp
+
+Purpose: show data freshness without making every screen feel like a dashboard.
+
+Recommended API:
+
+```ts
+type LastUpdatedStampProps = {
+  updatedAt: Date | string
+  staleAfterMs?: number
+  format?: 'relative' | 'absolute' | 'time'
+}
+```
+
+Acceptance criteria:
+
+- relative format reads clearly at distance
+- stale state can be styled without relying on color alone
+- supports timezone-safe formatting
+
+## Screen Role Blocks
+
+### ArrivalBoard
+
+Use for entrance, reception, lobby, and check-in contexts.
+
+Must support:
+
+- welcome message
+- current time or event cue
+- one primary orientation item
+- optional QR or short URL action
+- optional secondary service notice
+
+### WayfindingBoard
+
+Use for directions and local navigation.
+
+Must support:
+
+- current location
+- destination cards
+- floor or zone indicators
+- optional map slot
+- optional accessibility note
+
+### WaitingRoomBoard
+
+Use for dwell-heavy spaces where reassurance matters.
+
+Must support:
+
+- current status or wait expectation
+- calm primary message
+- optional rotating information
+- optional service reminder or QR handoff
+
+### DecisionBoard
+
+Use near ordering, purchasing, selection, or queue moments.
+
+Must support:
+
+- one dominant choice or offer
+- price or availability metadata
+- CTA strip
+- optional supporting comparison
+
+### OperationalStatusBoard
+
+Use for warehouses, transport, venues, factories, service counters, or incident displays.
+
+Must support:
+
+- status summary
+- severity tone
+- key metrics
+- last-updated stamp
+- fallback or stale-data states
+
+### WorkplaceShiftBoard
+
+Use for staff-facing screens around shift changes and internal communication.
+
+Must support:
+
+- shift or team context
+- current priorities
+- safety or operational notes
+- date/time
+- message owner or source
+
+## Display QA Components
+
+### BezelGrid
+
+Purpose: overlay video-wall panel boundaries so designers avoid placing important content across bezels.
+
+Acceptance criteria:
+
+- supports rows, columns, and gap width
+- can be used inside `ScreenFrame`
+- visually distinct in preview mode only
+
+### OverscanGuide
+
+Purpose: show safe margins for displays that may crop edges.
+
+Acceptance criteria:
+
+- supports percentage and pixel margins
+- can show warning zones
+- does not ship as visible production chrome by default
+
+### ReachZoneOverlay
+
+Purpose: preview touch reach constraints on portrait and kiosk screens.
+
+Acceptance criteria:
+
+- supports mounting height and screen size assumptions
+- marks comfortable, stretch, and avoid zones
+- includes examples for portrait 1080p and 4k landscape touch
+
+### ViewingDistancePreview
+
+Purpose: help developers validate type scale for known viewing distances.
+
+Acceptance criteria:
+
+- accepts viewing distance in metres or feet
+- flags text below recommended minimum sizes
+- works as a Storybook QA wrapper
+
+## Governance Components
+
+### MessageApprovalBadge
+
+Purpose: show whether content is draft, approved, scheduled, live, expired, or rejected.
+
+Recommended statuses:
+
+- `draft`
+- `approved`
+- `scheduled`
+- `live`
+- `expired`
+- `rejected`
+
+### ContentOwnerLabel
+
+Purpose: identify who owns a message or feed.
+
+Recommended fields:
+
+- owner name
+- department
+- contact or escalation label
+- optional source system
+
+### ExpiryDateBadge
+
+Purpose: make stale campaigns less likely by displaying content expiry in preview and admin surfaces.
+
+### LocalOverrideSlot
+
+Purpose: give local teams a controlled area without breaking mandatory global content.
+
+Acceptance criteria:
+
+- slot can be empty without collapsing the layout
+- mandatory content remains dominant
+- local override has visible ownership metadata in preview mode
+
+## Interactive Components
+
+### KioskHome
+
+Purpose: starting screen for touch signage.
+
+Must support:
+
+- large touch-safe navigation choices
+- optional language selector
+- persistent home context
+- idle reset integration
+
+### TouchNav
+
+Purpose: signage-sized navigation for shallow touch flows.
+
+Acceptance criteria:
+
+- no more than four primary choices by default
+- large touch targets
+- visible selected state
+- supports portrait reach zones
+
+### IdleReset
+
+Purpose: return abandoned sessions to a known state.
+
+Recommended API:
+
+```ts
+type IdleResetProps = {
+  timeoutMs: number
+  warningMs?: number
+  onReset: () => void
+  children: React.ReactNode
+}
+```
+
+### BackHomeControls
+
+Purpose: provide obvious recovery on touch screens.
+
+Acceptance criteria:
+
+- home and back controls are always reachable
+- controls are large enough for public touch use
+- works with `IdleReset`
+
+### QRHandoff
+
+Purpose: move a task from public screen to personal device.
+
+Acceptance criteria:
+
+- includes QR and short URL options
+- explains what continues on the phone
+- supports privacy-safe copy for public spaces
+
+## Storybook Requirements
+
+Every new component should include:
+
+- default story
+- dark and light or high-contrast story where relevant
+- 1080p landscape story
+- portrait story when layout-sensitive
+- stale, empty, expired, or offline state stories where relevant
+- realistic signage examples, not placeholder lorem ipsum
+
+## Registry Requirements
+
+Every public component should get:
+
+- registry entry
+- install command example
+- dependency list
+- usage snippet
+- screenshot or Storybook preview link
+
+Recommended registry names should use kebab case:
+
+- `playlist-timeline`
+- `qr-code-callout`
+- `one-message-frame`
+- `no-content-fallback`
+- `arrival-board`
+- `operational-status-board`
+- `bezel-grid`
+- `idle-reset`
+
+## Testing Requirements
+
+Component tests should cover:
+
+- render without crashing
+- required labels and content appear
+- expired, stale, offline, and empty states
+- time-sensitive behaviour with deterministic timers
+- accessibility basics for interactive components
+- no uncontrolled layout overflow in common resolutions where practical
+
+Visual QA should cover:
+
+- 1920x1080 landscape
+- 3840x2160 landscape for dense components
+- 1080x1920 portrait for touch and role blocks
+- reduced motion where animated
+
+## Non-Goals
+
+- Do not build a full CMS.
+- Do not build asset upload, user permissions, or billing UI here.
+- Do not make generic dashboard components unless they are adapted for wall-screen use.
+- Do not make every vertical block fully data-integrated at first. Static and prop-driven examples are enough for the first pass.
+- Do not expose technical error details on public playback screens by default.
+
+## Definition Of Done
+
+A component is ready when:
+
+- it solves a named signage job
+- its props make signage-specific context explicit
+- it behaves predictably at fixed display resolutions
+- it has Storybook coverage with realistic content
+- it has a registry entry
+- it has basic unit tests
+- it has documented empty, stale, expired, or offline states when those states apply
+
+## Suggested First Pull Request
+
+Implement the Phase 1 CTA and fallback set:
+
+- `QRCodeCallout`
+- `ShortUrlCallout`
+- `ActionStrip`
+- `OneMessageFrame`
+- `NoContentFallback`
+- `LastUpdatedStamp`
+- `ContentExpiredWarning`
+
+Why this first:
+
+- it improves almost every signage composition
+- it is smaller than playlist orchestration
+- it gives creators immediate building blocks for clearer screens
+- it creates the metadata patterns needed by later governance and operations components
+
+## Delivery Strategy
+
+Use grouped workstreams rather than one issue per component. The roadmap is broad enough that 30-plus single-component issues would create tracking noise before implementation starts.
+
+Each workstream issue should:
+
+- name the components included in scope
+- describe the shared signage job the group solves
+- include Storybook, tests, registry, and docs requirements
+- define any dependencies on earlier primitives
+- stay reviewable as one pull request or a short sequence of tightly related pull requests
+
+## Cross-Cutting Build Rules
+
+Every implementation issue in this roadmap should assume the following unless it explicitly says otherwise:
+
+- components live in `libs/shadcnui-signage`
+- new public components ship with exports and registry entries
+- stories use realistic signage data, not lorem ipsum or dashboard filler
+- time-sensitive behaviour uses deterministic timers in tests
+- interactive components include keyboard and focus handling where applicable
+- preview-only QA overlays do not leak into production defaults
+- public playback states avoid raw technical diagnostics unless a debug variant is requested
+
+## Dependency Notes
+
+- `PlaylistItem`, `PlaylistTimeline`, `LoopProgress`, and `PriorityTakeover` should land before board templates that need loop awareness
+- `QRCodeCallout`, `ShortUrlCallout`, `ActionStrip`, and `OneMessageFrame` should land before most promotional and decision-oriented boards
+- freshness and fallback primitives should land before live-data and operations boards
+- QA overlays can ship independently, but they become more useful once role blocks exist in Storybook
+- interactive kiosk patterns should depend on the reach-zone and idle-reset primitives rather than inventing separate touch rules
+
+## Issue Breakdown
+
+### Roadmap Epic
+
+Proposed title:
+
+- `feat(shadcnui-signage): Implement signage component gaps roadmap`
+
+Purpose:
+
+- track the overall roadmap
+- link the grouped implementation issues
+- keep the spec, sequencing, and follow-up decisions in one place
+
+### Workstream 1: Playlist Runtime Primitives
+
+Proposed title:
+
+- `feat(shadcnui-signage): Add playlist runtime primitives for timed signage loops`
+
+In scope:
+
+- `PlaylistTimeline`
+- `PlaylistItem`
+- `LoopProgress`
+- `PriorityTakeover`
+
+Exit criteria:
+
+- timed-loop metadata is modeled explicitly in component props
+- active, next, expired, and takeover states are all demonstrated in Storybook
+- the work establishes the base contract for later playlist orchestration
+
+### Workstream 2: CTA and Handoff Primitives
+
+Proposed title:
+
+- `feat(shadcnui-signage): Add CTA and QR handoff primitives for signage actions`
+
+In scope:
+
+- `QRCodeCallout`
+- `ShortUrlCallout`
+- `ActionStrip`
+- `QRHandoff`
+
+Exit criteria:
+
+- CTA patterns remain readable from distance
+- QR and short URL treatments work together cleanly
+- poster-style, side-zone, and footer CTA examples exist
+
+Related issue notes:
+
+- align with or supersede the narrower CTA banner work already tracked in issue `#53`
+
+### Workstream 3: Message Clarity and Freshness States
+
+Proposed title:
+
+- `feat(shadcnui-signage): Add message clarity, fallback, and freshness primitives`
+
+In scope:
+
+- `OneMessageFrame`
+- `NoContentFallback`
+- `ContentExpiredWarning`
+- `LastUpdatedStamp`
+- `ReconnectingState`
+
+Exit criteria:
+
+- creators can build a safe public fallback path without custom glue
+- stale, empty, expired, and reconnecting states are all documented and tested
+- preview or operator variants are separated from public-safe defaults
+
+### Workstream 4: Arrival and Decision Templates
+
+Proposed title:
+
+- `feat(shadcnui-signage): Add arrival, waiting, and decision board templates`
+
+In scope:
+
+- `ArrivalBoard`
+- `WaitingRoomBoard`
+- `DecisionBoard`
+
+Exit criteria:
+
+- each template demonstrates one dominant message plus one next step
+- optional QR and service notices fit without collapsing readability
+- landscape and portrait examples exist where the template meaningfully changes
+
+### Workstream 5: Wayfinding and Navigation Templates
+
+Proposed title:
+
+- `feat(shadcnui-signage): Add wayfinding board templates for navigational signage`
+
+In scope:
+
+- `WayfindingBoard`
+- optional integration point for map-based or floorplan content
+
+Exit criteria:
+
+- list-based and map-slot wayfinding compositions are both supported
+- current location and destination emphasis are clearly modeled
+- accessibility notes and floor or zone metadata have a defined place in the layout
+
+Related issue notes:
+
+- coordinate with the existing map-based wayfinding request in issue `#91`
+
+### Workstream 6: Operational and Schedule Boards
+
+Proposed title:
+
+- `feat(shadcnui-signage): Add operational, schedule, and shift board templates`
+
+In scope:
+
+- `OperationalStatusBoard`
+- `WorkplaceShiftBoard`
+- `EventScheduleBoard`
+- `RestaurantMenuBoard`
+
+Exit criteria:
+
+- boards combine existing primitives with the new freshness and fallback states
+- examples cover at least one live-data style screen and one menu-style screen
+- ownership, timing, and severity cues are built into the component contracts
+
+### Workstream 7: Screen QA and Physical Display Overlays
+
+Proposed title:
+
+- `feat(shadcnui-signage): Add screen QA overlays for physical display validation`
+
+In scope:
+
+- `BezelGrid`
+- `OverscanGuide`
+- `ReachZoneOverlay`
+- `ViewingDistancePreview`
+- `OrientationSwitcher`
+
+Exit criteria:
+
+- overlays are useful in Storybook and preview environments
+- they stay opt-in and hidden in production defaults
+- the work creates repeatable QA patterns for landscape, portrait, and touch validation
+
+### Workstream 8: Governance and Content Lifecycle Metadata
+
+Proposed title:
+
+- `feat(shadcnui-signage): Add governance metadata components for signage content lifecycle`
+
+In scope:
+
+- `MessageApprovalBadge`
+- `ContentOwnerLabel`
+- `ExpiryDateBadge`
+- `LocalOverrideSlot`
+- `DeploymentVersionBadge`
+
+Exit criteria:
+
+- approval, ownership, expiry, and override state can be shown consistently in preview and admin-oriented surfaces
+- local override patterns never displace mandatory content by default
+- deployment or version metadata has a clear operator-facing treatment
+
+### Workstream 9: Player and Runtime Operations States
+
+Proposed title:
+
+- `feat(shadcnui-signage): Add player health and runtime operations states`
+
+In scope:
+
+- `PlayerHealthPanel`
+- integration with `ReconnectingState`, `LastUpdatedStamp`, and fallback primitives
+
+Exit criteria:
+
+- operator-facing states are available without exposing noisy diagnostics to public playback
+- the work defines a reusable operational status surface for demos and internal tooling
+
+### Workstream 10: Touch and Kiosk Foundations
+
+Proposed title:
+
+- `feat(shadcnui-signage): Add touch and kiosk foundation components`
+
+In scope:
+
+- `KioskHome`
+- `TouchNav`
+- `IdleReset`
+- `BackHomeControls`
+
+Exit criteria:
+
+- touch-safe navigation is consistent across portrait kiosks and shallow flows
+- idle reset and home recovery are demonstrated in Storybook
+- reach-zone guidance informs default placement and sizing
+
+## Recommended Delivery Order
+
+1. Workstream 2: CTA and Handoff Primitives
+2. Workstream 3: Message Clarity and Freshness States
+3. Workstream 1: Playlist Runtime Primitives
+4. Workstream 7: Screen QA and Physical Display Overlays
+5. Workstream 4: Arrival and Decision Templates
+6. Workstream 5: Wayfinding and Navigation Templates
+7. Workstream 6: Operational and Schedule Boards
+8. Workstream 8: Governance and Content Lifecycle Metadata
+9. Workstream 9: Player and Runtime Operations States
+10. Workstream 10: Touch and Kiosk Foundations
+
+## Issue Creation Notes
+
+When creating GitHub issues from this spec:
+
+- create one parent roadmap issue and link each workstream to it
+- use GitHub `Feature` issue type
+- keep issue bodies grounded in signage jobs, not just component names
+- reference existing overlapping issues instead of silently duplicating them
+- call out whether an issue can land as one pull request or should be delivered as a short stack
+

--- a/docs/plans/2026-05-07-shadcn-registry-item-endpoints.md
+++ b/docs/plans/2026-05-07-shadcn-registry-item-endpoints.md
@@ -1,0 +1,28 @@
+# Shadcn Registry Item Endpoints Plan
+
+## Goal
+
+Make WallRun's published shadcn registry installable by exposing per-item JSON endpoints and updating docs to stop treating the collection registry as a single installable item.
+
+## Context
+
+- `apps/client/public/registry/registry.json` is a collection document with an `items` array.
+- Current install examples use `npx shadcn add <registry.json> <component-name>`, which makes the CLI parse the collection as a registry item and fail.
+- The published `registry/` folder does not currently include per-item `*.json` files.
+
+## Tasks
+
+1. Add a small sync script that derives `apps/client/public/registry/<name>.json` from the collection file.
+2. Generate the current item JSON artifacts in `apps/client/public/registry/`.
+3. Update shared install-command helpers and docs to use item endpoints or a registry template instead of the collection URL.
+4. Update maintainer guidance so the generated item files stay in sync with `registry.json`.
+
+## Validation
+
+- Run the sync script and confirm per-item JSON files exist in `apps/client/public/registry/`.
+- Run focused tests for the install-command rewrite logic.
+- Run a narrow typecheck or lint pass for the touched app files.
+
+## Expected Result
+
+Users can install a WallRun component with a valid shadcn registry item URL, and maintainers have a repeatable way to keep the published registry artifacts aligned.

--- a/docs/plans/2026-05-07-wallrun-signage-component-gaps-issues.md
+++ b/docs/plans/2026-05-07-wallrun-signage-component-gaps-issues.md
@@ -1,0 +1,28 @@
+# Plan: WallRun Signage Component Gaps Issues
+
+## Goal
+
+Enrich the component gaps spec so it is implementation-ready and create a matching GitHub issue set for the next tranche of `@wallrun/shadcnui-signage` work.
+
+## Context
+
+The current spec already names the missing component families, but it needs delivery structure before it can drive implementation. The main gaps are issue granularity, dependency ordering, cross-cutting acceptance rules, and explicit GitHub issue titles.
+
+## Tasks
+
+- extend `docs/new features/wallrun-signage-component-gaps-spec.md` with workstreams, dependency notes, and an issue map
+- keep the issue breakdown small enough to be reviewable while still covering the full roadmap
+- avoid duplicating existing open issues where a new grouped issue should explicitly reference or subsume narrower tickets
+- create GitHub `Feature` issues that mirror the enriched issue map
+
+## Deliverables
+
+- enriched spec with issue-ready sections
+- one parent roadmap issue
+- a set of grouped child issues for the main workstreams
+
+## Validation
+
+- spec includes clear issue titles, scope, dependencies, and exit criteria
+- each GitHub issue matches one entry in the spec
+- issue bodies reference cross-cutting requirements for Storybook, tests, registry, and realistic signage examples

--- a/docs/signage design briefs/The Lard Lounge/design brief.md
+++ b/docs/signage design briefs/The Lard Lounge/design brief.md
@@ -10,7 +10,7 @@ Color Palette: Bone white, translucent amber, deep mahogany, and a "surgical" ne
 Typography: A mix of a heavy, "greasy" serif for headers and a clean, monospaced font for descriptions to keep it readable.
 
 2. Technical Layout (Portrait 9:16)
-   Top Third: Animated Hero Shot. A rotating, translucent lard sculpture of a pig’s head that slowly melts and reforms.
+   Top Third: Animated Hero Shot. A rotating, translucent lard reliquary with crystalline folds that slowly melts and reforms.
 
 Middle Section: The "Main Curiosities." Two columns of text with plenty of negative space to prevent "visual indigestion."
 

--- a/libs/shadcnui-signage/src/index.ts
+++ b/libs/shadcnui-signage/src/index.ts
@@ -51,6 +51,8 @@ export type { SignageHeaderProps } from './lib/layouts/SignageHeader';
 // Blocks
 export { FullscreenHero } from './lib/blocks/FullscreenHero';
 export type { FullscreenHeroProps } from './lib/blocks/FullscreenHero';
+export { OneMessageFrame } from './lib/blocks/OneMessageFrame';
+export type { OneMessageFrameProps } from './lib/blocks/OneMessageFrame';
 export { InfoCardGrid } from './lib/blocks/InfoCardGrid';
 export type { InfoCardGridProps } from './lib/blocks/InfoCardGrid';
 export { MenuBoard } from './lib/blocks/MenuBoard';
@@ -75,8 +77,21 @@ export { Countdown } from './lib/behaviour/Countdown';
 export type { CountdownProps } from './lib/behaviour/Countdown';
 export { OfflineFallback } from './lib/behaviour/OfflineFallback';
 export type { OfflineFallbackProps } from './lib/behaviour/OfflineFallback';
+export { NoContentFallback } from './lib/behaviour/NoContentFallback';
+export type { NoContentFallbackProps } from './lib/behaviour/NoContentFallback';
 export { StaleDataIndicator } from './lib/behaviour/StaleDataIndicator';
 export type { StaleDataIndicatorProps } from './lib/behaviour/StaleDataIndicator';
+export { ContentExpiredWarning } from './lib/behaviour/ContentExpiredWarning';
+export type {
+  ContentExpiredWarningProps,
+} from './lib/behaviour/ContentExpiredWarning';
+export { LastUpdatedStamp } from './lib/behaviour/LastUpdatedStamp';
+export type {
+  LastUpdatedStampProps,
+  LastUpdatedStampFormat,
+} from './lib/behaviour/LastUpdatedStamp';
+export { ReconnectingState } from './lib/behaviour/ReconnectingState';
+export type { ReconnectingStateProps } from './lib/behaviour/ReconnectingState';
 
 // Types
 export type {

--- a/libs/shadcnui-signage/src/lib/behaviour/ContentExpiredWarning.stories.tsx
+++ b/libs/shadcnui-signage/src/lib/behaviour/ContentExpiredWarning.stories.tsx
@@ -1,0 +1,48 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { ContentExpiredWarning } from './ContentExpiredWarning';
+import { ScreenFrame } from '../primitives/ScreenFrame';
+
+const meta: Meta<typeof ContentExpiredWarning> = {
+  title: 'Signage/Behaviour/ContentExpiredWarning',
+  component: ContentExpiredWarning,
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <div className="bg-slate-950/95 p-8">
+        <ScreenFrame resolution="1080p" scale={0.42}>
+          <div className="relative h-full bg-[radial-gradient(circle_at_top,rgba(244,63,94,0.16),transparent_34%),linear-gradient(135deg,#020617,#111827_48%,#3f1d2e)] p-12 text-white lg:p-16">
+            <Story />
+          </div>
+        </ScreenFrame>
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof ContentExpiredWarning>;
+
+export const Badge: Story = {
+  args: {
+    expiredAt: '2026-05-07T09:45:00.000Z',
+    now: () => new Date('2026-05-07T10:00:00.000Z').getTime(),
+    variant: 'badge',
+  },
+};
+
+export const Panel: Story = {
+  args: {
+    expiredAt: '2026-05-07T08:15:00.000Z',
+    now: () => new Date('2026-05-07T10:00:00.000Z').getTime(),
+    variant: 'panel',
+    label: 'Promotion approval window closed',
+  },
+};
+
+export const Overlay: Story = {
+  args: {
+    expiredAt: '2026-05-07T09:30:00.000Z',
+    now: () => new Date('2026-05-07T10:00:00.000Z').getTime(),
+    variant: 'overlay',
+  },
+};

--- a/libs/shadcnui-signage/src/lib/behaviour/ContentExpiredWarning.test.tsx
+++ b/libs/shadcnui-signage/src/lib/behaviour/ContentExpiredWarning.test.tsx
@@ -44,6 +44,10 @@ describe('ContentExpiredWarning', () => {
       'data-variant',
       'panel',
     );
+    expect(screen.getByTestId('content-expired-warning')).toHaveAttribute(
+      'role',
+      'status',
+    );
 
     rerender(
       <ContentExpiredWarning
@@ -57,5 +61,18 @@ describe('ContentExpiredWarning', () => {
       'data-variant',
       'overlay',
     );
+    expect(screen.getByTestId('content-expired-warning')).toHaveAttribute(
+      'role',
+      'status',
+    );
+  });
+
+  it('renders nothing when expiredAt cannot be parsed', () => {
+    const { container } = render(
+      <ContentExpiredWarning expiredAt="not-a-date" />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+    expect(screen.queryByText(/NaN/u)).not.toBeInTheDocument();
   });
 });

--- a/libs/shadcnui-signage/src/lib/behaviour/ContentExpiredWarning.test.tsx
+++ b/libs/shadcnui-signage/src/lib/behaviour/ContentExpiredWarning.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { ContentExpiredWarning } from './ContentExpiredWarning';
+
+describe('ContentExpiredWarning', () => {
+  it('renders nothing when the content has not yet expired', () => {
+    const { container } = render(
+      <ContentExpiredWarning
+        expiredAt="2026-05-07T11:00:00.000Z"
+        now={() => new Date('2026-05-07T10:00:00.000Z').getTime()}
+      />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders a badge when content is expired', () => {
+    render(
+      <ContentExpiredWarning
+        expiredAt="2026-05-07T09:45:00.000Z"
+        now={() => new Date('2026-05-07T10:00:00.000Z').getTime()}
+      />,
+    );
+
+    expect(screen.getByTestId('content-expired-warning')).toHaveAttribute(
+      'data-variant',
+      'badge',
+    );
+    expect(screen.getByTestId('content-expired-warning')).toHaveTextContent(
+      'expired 15m ago',
+    );
+  });
+
+  it('supports panel and overlay variants', () => {
+    const { rerender } = render(
+      <ContentExpiredWarning
+        expiredAt="2026-05-07T09:00:00.000Z"
+        variant="panel"
+        now={() => new Date('2026-05-07T10:00:00.000Z').getTime()}
+      />,
+    );
+
+    expect(screen.getByTestId('content-expired-warning')).toHaveAttribute(
+      'data-variant',
+      'panel',
+    );
+
+    rerender(
+      <ContentExpiredWarning
+        expiredAt="2026-05-07T09:00:00.000Z"
+        variant="overlay"
+        now={() => new Date('2026-05-07T10:00:00.000Z').getTime()}
+      />,
+    );
+
+    expect(screen.getByTestId('content-expired-warning')).toHaveAttribute(
+      'data-variant',
+      'overlay',
+    );
+  });
+});

--- a/libs/shadcnui-signage/src/lib/behaviour/ContentExpiredWarning.tsx
+++ b/libs/shadcnui-signage/src/lib/behaviour/ContentExpiredWarning.tsx
@@ -11,7 +11,9 @@ export interface ContentExpiredWarningProps {
 }
 
 function toEpochMs(value: Date | string) {
-  return value instanceof Date ? value.getTime() : new Date(value).getTime();
+  const epochMs = value instanceof Date ? value.getTime() : new Date(value).getTime();
+
+  return Number.isFinite(epochMs) ? epochMs : null;
 }
 
 function formatAge(ageMs: number) {
@@ -41,6 +43,10 @@ export function ContentExpiredWarning({
   const current = (now ?? (() => Date.now()))();
   const expiredEpochMs = toEpochMs(expiredAt);
 
+  if (expiredEpochMs === null) {
+    return null;
+  }
+
   if (current < expiredEpochMs) {
     return null;
   }
@@ -56,6 +62,7 @@ export function ContentExpiredWarning({
         )}
         data-testid="content-expired-warning"
         data-variant="panel"
+        role="status"
       >
         <div className="flex items-start gap-4">
           <AlertTriangle aria-hidden="true" className="mt-1 h-6 w-6 shrink-0" />

--- a/libs/shadcnui-signage/src/lib/behaviour/ContentExpiredWarning.tsx
+++ b/libs/shadcnui-signage/src/lib/behaviour/ContentExpiredWarning.tsx
@@ -1,0 +1,113 @@
+import { AlertTriangle } from 'lucide-react';
+import { cn } from '../utils/cn';
+import type { NowProvider } from '../types/time.types';
+
+export interface ContentExpiredWarningProps {
+  expiredAt: Date | string;
+  label?: string;
+  variant?: 'badge' | 'panel' | 'overlay';
+  now?: NowProvider;
+  className?: string;
+}
+
+function toEpochMs(value: Date | string) {
+  return value instanceof Date ? value.getTime() : new Date(value).getTime();
+}
+
+function formatAge(ageMs: number) {
+  const ageMin = Math.floor(ageMs / 60_000);
+  if (ageMin < 60) {
+    return `${Math.max(ageMin, 1)}m ago`;
+  }
+
+  const ageHours = Math.floor(ageMin / 60);
+  if (ageHours < 24) {
+    return `${ageHours}h ago`;
+  }
+
+  return `${Math.floor(ageHours / 24)}d ago`;
+}
+
+/**
+ * Highlights content that is beyond its approved display window.
+ */
+export function ContentExpiredWarning({
+  expiredAt,
+  label = 'Content expired',
+  variant = 'badge',
+  now,
+  className,
+}: ContentExpiredWarningProps) {
+  const current = (now ?? (() => Date.now()))();
+  const expiredEpochMs = toEpochMs(expiredAt);
+
+  if (current < expiredEpochMs) {
+    return null;
+  }
+
+  const expiredText = formatAge(current - expiredEpochMs);
+
+  if (variant === 'panel') {
+    return (
+      <section
+        className={cn(
+          'rounded-[1.75rem] border border-rose-300/20 bg-rose-400/10 p-6 text-rose-50 shadow-[0_18px_56px_rgba(136,19,55,0.24)] lg:p-8',
+          className,
+        )}
+        data-testid="content-expired-warning"
+        data-variant="panel"
+      >
+        <div className="flex items-start gap-4">
+          <AlertTriangle aria-hidden="true" className="mt-1 h-6 w-6 shrink-0" />
+          <div>
+            <div className="text-sm font-medium uppercase tracking-[0.24em] text-rose-100/75 lg:text-base">
+              Expired content
+            </div>
+            <div className="mt-3 text-3xl font-semibold tracking-tight lg:text-4xl">
+              {label}
+            </div>
+            <p className="mt-3 text-lg text-rose-50/85 lg:text-xl">
+              Expired {expiredText}. Remove from the live loop or replace with an approved fallback.
+            </p>
+          </div>
+        </div>
+      </section>
+    );
+  }
+
+  if (variant === 'overlay') {
+    return (
+      <div
+        className={cn(
+          'absolute inset-x-6 top-6 z-20 inline-flex items-center justify-center gap-3 rounded-full border border-rose-300/25 bg-rose-500/90 px-6 py-3 text-lg font-semibold text-white shadow-lg backdrop-blur-sm',
+          className,
+        )}
+        data-testid="content-expired-warning"
+        data-variant="overlay"
+        role="status"
+      >
+        <AlertTriangle aria-hidden="true" className="h-5 w-5 shrink-0" />
+        <span>
+          {label} • expired {expiredText}
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={cn(
+        'inline-flex items-center gap-2 rounded-full border border-rose-300/20 bg-rose-400/10 px-3 py-1.5 text-sm font-medium text-rose-50 lg:text-base',
+        className,
+      )}
+      data-testid="content-expired-warning"
+      data-variant="badge"
+      role="status"
+    >
+      <AlertTriangle aria-hidden="true" className="h-4 w-4 shrink-0" />
+      <span>
+        {label} • expired {expiredText}
+      </span>
+    </div>
+  );
+}

--- a/libs/shadcnui-signage/src/lib/behaviour/LastUpdatedStamp.stories.tsx
+++ b/libs/shadcnui-signage/src/lib/behaviour/LastUpdatedStamp.stories.tsx
@@ -1,0 +1,50 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { LastUpdatedStamp } from './LastUpdatedStamp';
+import { ScreenFrame } from '../primitives/ScreenFrame';
+
+const meta: Meta<typeof LastUpdatedStamp> = {
+  title: 'Signage/Behaviour/LastUpdatedStamp',
+  component: LastUpdatedStamp,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'LastUpdatedStamp keeps freshness visible without turning every signage surface into a dashboard. It is best used as a quiet utility marker on live data screens, operational boards, and feed-backed messages.',
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="bg-slate-950/95 p-8">
+        <ScreenFrame resolution="1080p" scale={0.42}>
+          <div className="flex h-full items-end bg-[radial-gradient(circle_at_top,rgba(14,165,233,0.14),transparent_34%),linear-gradient(135deg,#020617,#0f172a_52%,#111827)] p-12 text-white lg:p-16">
+            <Story />
+          </div>
+        </ScreenFrame>
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof LastUpdatedStamp>;
+
+export const FreshRelative: Story = {
+  args: {
+    updatedAt: '2026-05-07T09:56:00.000Z',
+    now: () => new Date('2026-05-07T10:00:00.000Z').getTime(),
+    format: 'relative',
+  },
+};
+
+export const StaleAbsolute: Story = {
+  args: {
+    updatedAt: '2026-05-07T06:45:00.000Z',
+    now: () => new Date('2026-05-07T10:00:00.000Z').getTime(),
+    staleAfterMs: 20 * 60_000,
+    format: 'absolute',
+    locale: 'en-US',
+    timeZone: 'UTC',
+  },
+};

--- a/libs/shadcnui-signage/src/lib/behaviour/LastUpdatedStamp.test.tsx
+++ b/libs/shadcnui-signage/src/lib/behaviour/LastUpdatedStamp.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { LastUpdatedStamp } from './LastUpdatedStamp';
+
+describe('LastUpdatedStamp', () => {
+  it('renders a relative freshness label', () => {
+    render(
+      <LastUpdatedStamp
+        updatedAt="2026-05-07T09:55:00.000Z"
+        now={() => new Date('2026-05-07T10:00:00.000Z').getTime()}
+      />,
+    );
+
+    expect(screen.getByTestId('last-updated-stamp')).toHaveTextContent(
+      'Last updated 5m ago',
+    );
+  });
+
+  it('marks stale data explicitly in text and attributes', () => {
+    render(
+      <LastUpdatedStamp
+        updatedAt="2026-05-07T08:00:00.000Z"
+        staleAfterMs={15 * 60_000}
+        now={() => new Date('2026-05-07T10:00:00.000Z').getTime()}
+      />,
+    );
+
+    expect(screen.getByTestId('last-updated-stamp')).toHaveAttribute(
+      'data-stale',
+      'true',
+    );
+    expect(screen.getByTestId('last-updated-stamp')).toHaveTextContent('stale');
+  });
+
+  it('supports deterministic absolute formatting', () => {
+    render(
+      <LastUpdatedStamp
+        updatedAt="2026-05-07T10:00:00.000Z"
+        format="absolute"
+        locale="en-US"
+        timeZone="UTC"
+      />,
+    );
+
+    expect(screen.getByTestId('last-updated-stamp')).toHaveTextContent(
+      'Last updated May 7, 10:00 AM',
+    );
+  });
+});

--- a/libs/shadcnui-signage/src/lib/behaviour/LastUpdatedStamp.test.tsx
+++ b/libs/shadcnui-signage/src/lib/behaviour/LastUpdatedStamp.test.tsx
@@ -43,7 +43,25 @@ describe('LastUpdatedStamp', () => {
     );
 
     expect(screen.getByTestId('last-updated-stamp')).toHaveTextContent(
-      'Last updated May 7, 10:00 AM',
+      /Last updated May 7, 10:00\sAM/u,
+    );
+  });
+
+  it('falls back safely when updatedAt cannot be parsed', () => {
+    render(<LastUpdatedStamp updatedAt="not-a-date" />);
+
+    expect(screen.getByTestId('last-updated-stamp')).toHaveTextContent(
+      'Last updated unavailable',
+    );
+    expect(screen.getByTestId('last-updated-stamp')).toHaveAttribute(
+      'data-stale',
+      'true',
+    );
+    expect(screen.getByTestId('last-updated-stamp')).not.toHaveTextContent(
+      'Invalid Date',
+    );
+    expect(screen.getByTestId('last-updated-stamp')).not.toHaveTextContent(
+      'NaN',
     );
   });
 });

--- a/libs/shadcnui-signage/src/lib/behaviour/LastUpdatedStamp.tsx
+++ b/libs/shadcnui-signage/src/lib/behaviour/LastUpdatedStamp.tsx
@@ -1,0 +1,120 @@
+import { useMemo } from 'react';
+import { AlertTriangle, Clock3 } from 'lucide-react';
+import { cn } from '../utils/cn';
+import type { NowProvider } from '../types/time.types';
+import { useTicker } from '../hooks/useTicker';
+
+export type LastUpdatedStampFormat = 'relative' | 'absolute' | 'time';
+
+export interface LastUpdatedStampProps {
+  updatedAt: Date | string;
+  staleAfterMs?: number;
+  format?: LastUpdatedStampFormat;
+  locale?: string;
+  timeZone?: string;
+  now?: NowProvider;
+  className?: string;
+}
+
+function toEpochMs(value: Date | string) {
+  return value instanceof Date ? value.getTime() : new Date(value).getTime();
+}
+
+function formatRelativeAge(ageMs: number) {
+  if (ageMs < 60_000) {
+    return 'just now';
+  }
+
+  const ageMin = Math.floor(ageMs / 60_000);
+  if (ageMin < 60) {
+    return `${ageMin}m ago`;
+  }
+
+  const ageHours = Math.floor(ageMin / 60);
+  if (ageHours < 24) {
+    return `${ageHours}h ago`;
+  }
+
+  const ageDays = Math.floor(ageHours / 24);
+  return `${ageDays}d ago`;
+}
+
+function formatTimestamp(
+  value: Date,
+  format: LastUpdatedStampFormat,
+  locale?: string,
+  timeZone?: string,
+) {
+  if (format === 'time') {
+    return new Intl.DateTimeFormat(locale, {
+      hour: 'numeric',
+      minute: '2-digit',
+      timeZone,
+    }).format(value);
+  }
+
+  return new Intl.DateTimeFormat(locale, {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+    timeZone,
+  }).format(value);
+}
+
+/**
+ * Shows when a feed or message was last updated without overpowering the main content.
+ */
+export function LastUpdatedStamp({
+  updatedAt,
+  staleAfterMs = 15 * 60_000,
+  format = 'relative',
+  locale,
+  timeZone,
+  now,
+  className,
+}: LastUpdatedStampProps) {
+  useTicker({
+    intervalMs: 60_000,
+    alignTo: format === 'relative' ? 'minute' : 'none',
+    now,
+  });
+
+  const current = (now ?? (() => Date.now()))();
+  const updatedEpochMs = toEpochMs(updatedAt);
+  const ageMs = Math.max(0, current - updatedEpochMs);
+  const stale = ageMs >= staleAfterMs;
+
+  const dateValue = useMemo(() => new Date(updatedEpochMs), [updatedEpochMs]);
+
+  const text =
+    format === 'relative'
+      ? formatRelativeAge(ageMs)
+      : formatTimestamp(dateValue, format, locale, timeZone);
+
+  return (
+    <div
+      className={cn(
+        'inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-sm font-medium tracking-[0.02em] sm:text-base',
+        stale
+          ? 'border-amber-300/30 bg-amber-400/12 text-amber-50'
+          : 'border-white/12 bg-white/6 text-slate-100',
+        className,
+      )}
+      role="status"
+      aria-label={`Last updated ${text}${stale ? ', stale' : ''}`}
+      data-testid="last-updated-stamp"
+      data-stale={stale ? 'true' : 'false'}
+    >
+      {stale ? (
+        <AlertTriangle aria-hidden="true" className="h-4 w-4 shrink-0" />
+      ) : (
+        <Clock3 aria-hidden="true" className="h-4 w-4 shrink-0" />
+      )}
+      <span>
+        Last updated {text}
+        {stale ? ' • stale' : ''}
+      </span>
+    </div>
+  );
+}

--- a/libs/shadcnui-signage/src/lib/behaviour/LastUpdatedStamp.tsx
+++ b/libs/shadcnui-signage/src/lib/behaviour/LastUpdatedStamp.tsx
@@ -1,4 +1,3 @@
-import { useMemo } from 'react';
 import { AlertTriangle, Clock3 } from 'lucide-react';
 import { cn } from '../utils/cn';
 import type { NowProvider } from '../types/time.types';
@@ -17,7 +16,9 @@ export interface LastUpdatedStampProps {
 }
 
 function toEpochMs(value: Date | string) {
-  return value instanceof Date ? value.getTime() : new Date(value).getTime();
+  const epochMs = value instanceof Date ? value.getTime() : new Date(value).getTime();
+
+  return Number.isFinite(epochMs) ? epochMs : null;
 }
 
 function formatRelativeAge(ageMs: number) {
@@ -82,15 +83,15 @@ export function LastUpdatedStamp({
 
   const current = (now ?? (() => Date.now()))();
   const updatedEpochMs = toEpochMs(updatedAt);
-  const ageMs = Math.max(0, current - updatedEpochMs);
-  const stale = ageMs >= staleAfterMs;
-
-  const dateValue = useMemo(() => new Date(updatedEpochMs), [updatedEpochMs]);
+  const ageMs = updatedEpochMs === null ? null : Math.max(0, current - updatedEpochMs);
+  const stale = updatedEpochMs === null || ageMs >= staleAfterMs;
 
   const text =
-    format === 'relative'
-      ? formatRelativeAge(ageMs)
-      : formatTimestamp(dateValue, format, locale, timeZone);
+    updatedEpochMs === null
+      ? 'unavailable'
+      : format === 'relative'
+        ? formatRelativeAge(ageMs)
+        : formatTimestamp(new Date(updatedEpochMs), format, locale, timeZone);
 
   return (
     <div

--- a/libs/shadcnui-signage/src/lib/behaviour/NoContentFallback.stories.tsx
+++ b/libs/shadcnui-signage/src/lib/behaviour/NoContentFallback.stories.tsx
@@ -1,0 +1,42 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { NoContentFallback } from './NoContentFallback';
+import { ScreenFrame } from '../primitives/ScreenFrame';
+
+const meta: Meta<typeof NoContentFallback> = {
+  title: 'Signage/Behaviour/NoContentFallback',
+  component: NoContentFallback,
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <div className="bg-slate-950/95 p-8">
+        <ScreenFrame resolution="1080p" scale={0.42}>
+          <div className="h-full bg-[radial-gradient(circle_at_top,rgba(245,158,11,0.14),transparent_34%),linear-gradient(135deg,#020617,#111827_48%,#312e81)] p-12 text-white lg:p-16">
+            <Story />
+          </div>
+        </ScreenFrame>
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof NoContentFallback>;
+
+export const PublicSafe: Story = {
+  args: {
+    title: 'Live updates temporarily unavailable',
+    message:
+      'Please use the assistance desk beside this screen for the latest service information.',
+  },
+};
+
+export const OperatorDebug: Story = {
+  args: {
+    variant: 'operator-debug',
+    title: 'Playlist returned no valid items',
+    message:
+      'The public screen should stay useful while operations teams confirm the source feed and schedule window.',
+    owner: 'Transport operations',
+    lastCheckedAt: '2026-05-07T09:56:00.000Z',
+  },
+};

--- a/libs/shadcnui-signage/src/lib/behaviour/NoContentFallback.test.tsx
+++ b/libs/shadcnui-signage/src/lib/behaviour/NoContentFallback.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { NoContentFallback } from './NoContentFallback';
+
+describe('NoContentFallback', () => {
+  it('renders a public-safe fallback by default', () => {
+    render(<NoContentFallback />);
+
+    expect(screen.getByTestId('no-content-fallback')).toHaveAttribute(
+      'data-variant',
+      'public-safe',
+    );
+    expect(screen.queryByTestId('no-content-debug-meta')).not.toBeInTheDocument();
+  });
+
+  it('renders owner and last-checked metadata in operator mode', () => {
+    render(
+      <NoContentFallback
+        variant="operator-debug"
+        owner="Campus operations"
+        lastCheckedAt="2026-05-07T10:00:00.000Z"
+      />,
+    );
+
+    expect(screen.getByTestId('no-content-debug-meta')).toBeInTheDocument();
+    expect(screen.getByText(/Owner: Campus operations/)).toBeInTheDocument();
+    expect(screen.getByTestId('last-updated-stamp')).toBeInTheDocument();
+  });
+});

--- a/libs/shadcnui-signage/src/lib/behaviour/NoContentFallback.tsx
+++ b/libs/shadcnui-signage/src/lib/behaviour/NoContentFallback.tsx
@@ -1,0 +1,64 @@
+import { cn } from '../utils/cn';
+import { LastUpdatedStamp } from './LastUpdatedStamp';
+
+export interface NoContentFallbackProps {
+  title?: string;
+  message?: string;
+  owner?: string;
+  lastCheckedAt?: Date | string;
+  variant?: 'public-safe' | 'operator-debug';
+  className?: string;
+}
+
+/**
+ * Prevents blank display regions when a feed, playlist, or schedule has nothing safe to show.
+ */
+export function NoContentFallback({
+  title = 'Content temporarily unavailable',
+  message = 'Please refer to the desk beside this screen for the latest assistance.',
+  owner,
+  lastCheckedAt,
+  variant = 'public-safe',
+  className,
+}: NoContentFallbackProps) {
+  const debugMode = variant === 'operator-debug';
+
+  return (
+    <section
+      className={cn(
+        'rounded-[2rem] border p-8 shadow-[0_24px_80px_rgba(2,6,23,0.32)] lg:p-10',
+        debugMode
+          ? 'border-amber-300/20 bg-amber-400/10 text-amber-50'
+          : 'border-white/10 bg-slate-950/72 text-white',
+        className,
+      )}
+      data-testid="no-content-fallback"
+      data-variant={variant}
+    >
+      <div className="text-base font-medium uppercase tracking-[0.28em] text-inherit/75 lg:text-lg">
+        {debugMode ? 'Operator fallback' : 'Fallback message'}
+      </div>
+      <h2 className="mt-4 text-4xl font-semibold tracking-tight lg:text-5xl">
+        {title}
+      </h2>
+      <p className="mt-4 max-w-4xl text-xl leading-relaxed text-inherit/85 lg:text-2xl">
+        {message}
+      </p>
+      {debugMode ? (
+        <div className="mt-8 flex flex-wrap items-center gap-4" data-testid="no-content-debug-meta">
+          {owner ? (
+            <div className="rounded-full border border-amber-100/15 bg-slate-950/30 px-4 py-2 text-sm font-medium uppercase tracking-[0.22em] text-amber-50/85 lg:text-base">
+              Owner: {owner}
+            </div>
+          ) : null}
+          {lastCheckedAt ? (
+            <LastUpdatedStamp
+              updatedAt={lastCheckedAt}
+              className="border-amber-100/15 bg-slate-950/30 text-amber-50"
+            />
+          ) : null}
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/libs/shadcnui-signage/src/lib/behaviour/ReconnectingState.stories.tsx
+++ b/libs/shadcnui-signage/src/lib/behaviour/ReconnectingState.stories.tsx
@@ -1,0 +1,40 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { ReconnectingState } from './ReconnectingState';
+import { ScreenFrame } from '../primitives/ScreenFrame';
+
+const meta: Meta<typeof ReconnectingState> = {
+  title: 'Signage/Behaviour/ReconnectingState',
+  component: ReconnectingState,
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <div className="bg-slate-950/95 p-8">
+        <ScreenFrame resolution="1080p" scale={0.42}>
+          <div className="h-full bg-[radial-gradient(circle_at_top,rgba(56,189,248,0.16),transparent_34%),linear-gradient(135deg,#020617,#0f172a_48%,#0c4a6e)] p-12 text-white lg:p-16">
+            <Story />
+          </div>
+        </ScreenFrame>
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof ReconnectingState>;
+
+export const Panel: Story = {
+  args: {
+    active: true,
+    lastConnectedAt: '2026-05-07T09:56:00.000Z',
+    now: () => new Date('2026-05-07T10:00:00.000Z').getTime(),
+  },
+};
+
+export const Inline: Story = {
+  args: {
+    active: true,
+    variant: 'inline',
+    lastConnectedAt: '2026-05-07T09:58:00.000Z',
+    now: () => new Date('2026-05-07T10:00:00.000Z').getTime(),
+  },
+};

--- a/libs/shadcnui-signage/src/lib/behaviour/ReconnectingState.test.tsx
+++ b/libs/shadcnui-signage/src/lib/behaviour/ReconnectingState.test.tsx
@@ -36,4 +36,21 @@ describe('ReconnectingState', () => {
       'Last live 5m ago',
     );
   });
+
+  it('omits last live metadata when lastConnectedAt cannot be parsed', () => {
+    render(
+      <ReconnectingState
+        active={true}
+        variant="inline"
+        lastConnectedAt="not-a-date"
+      />,
+    );
+
+    expect(screen.getByTestId('reconnecting-state')).not.toHaveTextContent(
+      'Last live',
+    );
+    expect(screen.getByTestId('reconnecting-state')).not.toHaveTextContent(
+      'NaN',
+    );
+  });
 });

--- a/libs/shadcnui-signage/src/lib/behaviour/ReconnectingState.test.tsx
+++ b/libs/shadcnui-signage/src/lib/behaviour/ReconnectingState.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { ReconnectingState } from './ReconnectingState';
+
+describe('ReconnectingState', () => {
+  it('renders nothing when inactive', () => {
+    const { container } = render(<ReconnectingState active={false} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders a panel when active', () => {
+    render(<ReconnectingState active={true} />);
+
+    expect(screen.getByTestId('reconnecting-state')).toHaveAttribute(
+      'data-variant',
+      'panel',
+    );
+  });
+
+  it('supports the inline variant with last live metadata', () => {
+    render(
+      <ReconnectingState
+        active={true}
+        variant="inline"
+        lastConnectedAt="2026-05-07T09:55:00.000Z"
+        now={() => new Date('2026-05-07T10:00:00.000Z').getTime()}
+      />,
+    );
+
+    expect(screen.getByTestId('reconnecting-state')).toHaveAttribute(
+      'data-variant',
+      'inline',
+    );
+    expect(screen.getByTestId('reconnecting-state')).toHaveTextContent(
+      'Last live 5m ago',
+    );
+  });
+});

--- a/libs/shadcnui-signage/src/lib/behaviour/ReconnectingState.tsx
+++ b/libs/shadcnui-signage/src/lib/behaviour/ReconnectingState.tsx
@@ -1,0 +1,103 @@
+import { RefreshCw } from 'lucide-react';
+import { cn } from '../utils/cn';
+import type { NowProvider } from '../types/time.types';
+
+export interface ReconnectingStateProps {
+  active: boolean;
+  title?: string;
+  message?: string;
+  lastConnectedAt?: Date | string;
+  variant?: 'inline' | 'panel';
+  now?: NowProvider;
+  className?: string;
+}
+
+function toEpochMs(value: Date | string) {
+  return value instanceof Date ? value.getTime() : new Date(value).getTime();
+}
+
+function formatAge(ageMs: number) {
+  if (ageMs < 60_000) {
+    return 'moments ago';
+  }
+
+  const ageMin = Math.floor(ageMs / 60_000);
+  if (ageMin < 60) {
+    return `${ageMin}m ago`;
+  }
+
+  const ageHours = Math.floor(ageMin / 60);
+  return `${ageHours}h ago`;
+}
+
+/**
+ * Announces that a live region is reconnecting without collapsing the surrounding layout.
+ */
+export function ReconnectingState({
+  active,
+  title = 'Reconnecting live content',
+  message = 'Trying to restore the live feed without interrupting the rest of the screen.',
+  lastConnectedAt,
+  variant = 'panel',
+  now,
+  className,
+}: ReconnectingStateProps) {
+  if (!active) {
+    return null;
+  }
+
+  const current = (now ?? (() => Date.now()))();
+  const lastLiveText = lastConnectedAt
+    ? `Last live ${formatAge(Math.max(0, current - toEpochMs(lastConnectedAt)))}`
+    : undefined;
+
+  if (variant === 'inline') {
+    return (
+      <div
+        className={cn(
+          'inline-flex items-center gap-3 rounded-full border border-sky-300/20 bg-sky-400/10 px-4 py-2 text-sm font-medium text-sky-50 lg:text-base',
+          className,
+        )}
+        data-testid="reconnecting-state"
+        data-variant="inline"
+        role="status"
+      >
+        <RefreshCw aria-hidden="true" className="h-4 w-4 shrink-0 motion-safe:animate-spin motion-reduce:animate-none" />
+        <span>
+          {title}
+          {lastLiveText ? ` • ${lastLiveText}` : ''}
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <section
+      className={cn(
+        'rounded-[1.75rem] border border-sky-300/20 bg-sky-400/10 p-6 text-sky-50 shadow-[0_18px_56px_rgba(12,74,110,0.18)] lg:p-8',
+        className,
+      )}
+      data-testid="reconnecting-state"
+      data-variant="panel"
+      role="status"
+    >
+      <div className="flex items-start gap-4">
+        <RefreshCw aria-hidden="true" className="mt-1 h-6 w-6 shrink-0 motion-safe:animate-spin motion-reduce:animate-none" />
+        <div>
+          <div className="text-sm font-medium uppercase tracking-[0.24em] text-sky-100/75 lg:text-base">
+            Live feed recovery
+          </div>
+          <div className="mt-3 text-3xl font-semibold tracking-tight lg:text-4xl">
+            {title}
+          </div>
+          <p className="mt-3 text-lg text-sky-50/85 lg:text-xl">{message}</p>
+          {lastLiveText ? (
+            <div className="mt-4 text-sm font-medium uppercase tracking-[0.18em] text-sky-100/70 lg:text-base">
+              {lastLiveText}
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/libs/shadcnui-signage/src/lib/behaviour/ReconnectingState.tsx
+++ b/libs/shadcnui-signage/src/lib/behaviour/ReconnectingState.tsx
@@ -13,7 +13,9 @@ export interface ReconnectingStateProps {
 }
 
 function toEpochMs(value: Date | string) {
-  return value instanceof Date ? value.getTime() : new Date(value).getTime();
+  const epochMs = value instanceof Date ? value.getTime() : new Date(value).getTime();
+
+  return Number.isFinite(epochMs) ? epochMs : null;
 }
 
 function formatAge(ageMs: number) {
@@ -47,9 +49,11 @@ export function ReconnectingState({
   }
 
   const current = (now ?? (() => Date.now()))();
-  const lastLiveText = lastConnectedAt
-    ? `Last live ${formatAge(Math.max(0, current - toEpochMs(lastConnectedAt)))}`
-    : undefined;
+  const lastConnectedEpochMs = lastConnectedAt ? toEpochMs(lastConnectedAt) : null;
+  const lastLiveText =
+    lastConnectedEpochMs === null
+      ? undefined
+      : `Last live ${formatAge(Math.max(0, current - lastConnectedEpochMs))}`;
 
   if (variant === 'inline') {
     return (

--- a/libs/shadcnui-signage/src/lib/blocks/OneMessageFrame.spec.tsx
+++ b/libs/shadcnui-signage/src/lib/blocks/OneMessageFrame.spec.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { OneMessageFrame } from './OneMessageFrame';
+
+describe('OneMessageFrame', () => {
+  it('renders the headline as the dominant content', () => {
+    render(<OneMessageFrame headline="Boarding now in Hall B" />);
+
+    expect(screen.getByTestId('one-message-headline')).toHaveTextContent(
+      'Boarding now in Hall B',
+    );
+  });
+
+  it('renders supporting text with a safe clamp', () => {
+    render(
+      <OneMessageFrame
+        headline="Reception has moved"
+        supportingText="Please follow the illuminated floor markers to the temporary check-in desk beside the atrium stairs."
+      />,
+    );
+
+    expect(screen.getByTestId('one-message-supporting-text')).toHaveClass(
+      'line-clamp-3',
+    );
+  });
+
+  it('renders optional utility, action, and media regions', () => {
+    render(
+      <OneMessageFrame
+        headline="The next keynote starts in 12 minutes"
+        utility="Main stage"
+        action={<div>Scan for agenda updates</div>}
+        media={<div>Preview artwork</div>}
+      />,
+    );
+
+    expect(screen.getByTestId('one-message-utility')).toHaveTextContent(
+      'Main stage',
+    );
+    expect(screen.getByTestId('one-message-action')).toHaveTextContent(
+      'Scan for agenda updates',
+    );
+    expect(screen.getByTestId('one-message-media')).toHaveTextContent(
+      'Preview artwork',
+    );
+  });
+});

--- a/libs/shadcnui-signage/src/lib/blocks/OneMessageFrame.stories.tsx
+++ b/libs/shadcnui-signage/src/lib/blocks/OneMessageFrame.stories.tsx
@@ -1,0 +1,64 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { OneMessageFrame } from './OneMessageFrame';
+import { ScreenFrame } from '../primitives/ScreenFrame';
+
+const meta: Meta<typeof OneMessageFrame> = {
+  title: 'Signage/Blocks/OneMessageFrame',
+  component: OneMessageFrame,
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <div className="bg-slate-950/95 p-8">
+        <ScreenFrame resolution="1080p" scale={0.4}>
+          <div className="h-full bg-[radial-gradient(circle_at_top,rgba(59,130,246,0.14),transparent_34%),linear-gradient(135deg,#020617,#0f172a_48%,#111827)] p-12 lg:p-16">
+            <Story />
+          </div>
+        </ScreenFrame>
+      </div>
+    ),
+  ],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'OneMessageFrame is the opinionated single-message shell for signage surfaces that need one dominant statement, one short context line, and one next step.',
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof OneMessageFrame>;
+
+export const LobbyUpdate: Story = {
+  args: {
+    utility: 'Reception notice',
+    headline: 'Visitor check-in has moved to Desk 3',
+    supportingText:
+      'Please use the illuminated route beside the atrium stairs. Staff will redirect anyone arriving at the former desk.',
+    action: (
+      <div className="inline-flex rounded-full border border-white/15 bg-white px-8 py-4 text-2xl font-semibold text-slate-950">
+        Follow the floor markers
+      </div>
+    ),
+  },
+};
+
+export const WithMediaPanel: Story = {
+  args: {
+    utility: 'Event hall',
+    headline: 'The next keynote begins in 12 minutes',
+    supportingText:
+      'Scan the agenda for speaker notes, overflow seating, and live caption settings before the doors close.',
+    action: (
+      <div className="inline-flex rounded-full border border-sky-300/20 bg-sky-300/12 px-8 py-4 text-2xl font-semibold text-sky-50">
+        Scan for agenda updates
+      </div>
+    ),
+    media: (
+      <div className="flex h-full w-full items-center justify-center rounded-[1.5rem] bg-[linear-gradient(135deg,rgba(56,189,248,0.22),rgba(30,41,59,0.7))] text-center text-3xl font-medium text-slate-50 lg:text-4xl">
+        Speaker preview artwork
+      </div>
+    ),
+  },
+};

--- a/libs/shadcnui-signage/src/lib/blocks/OneMessageFrame.tsx
+++ b/libs/shadcnui-signage/src/lib/blocks/OneMessageFrame.tsx
@@ -1,0 +1,82 @@
+import type { ReactNode } from 'react';
+import { cn } from '../utils/cn';
+import { getClampClass } from '../utils/clamp';
+
+export interface OneMessageFrameProps {
+  headline: string;
+  supportingText?: string;
+  action?: ReactNode;
+  media?: ReactNode;
+  utility?: ReactNode;
+  className?: string;
+}
+
+/**
+ * Enforces a signage-safe layout with one dominant message and one clear next step.
+ */
+export function OneMessageFrame({
+  headline,
+  supportingText,
+  action,
+  media,
+  utility,
+  className,
+}: OneMessageFrameProps) {
+  const hasMedia = Boolean(media);
+
+  return (
+    <section
+      className={cn(
+        'grid h-full w-full gap-10 rounded-[2rem] border border-white/10 bg-slate-950/70 p-8 text-white shadow-[0_24px_80px_rgba(2,6,23,0.4)] lg:p-12',
+        hasMedia ? 'lg:grid-cols-[1.15fr_0.85fr] lg:items-center' : 'max-w-6xl',
+        className,
+      )}
+      data-testid="one-message-frame"
+      data-has-media={hasMedia ? 'true' : 'false'}
+    >
+      <div className="flex min-h-0 flex-col justify-center gap-6 lg:gap-8">
+        {utility ? (
+          <div
+            className="text-base font-medium uppercase tracking-[0.28em] text-slate-300 lg:text-lg"
+            data-testid="one-message-utility"
+          >
+            {utility}
+          </div>
+        ) : null}
+        <h1
+          className="text-6xl font-semibold tracking-tight text-white sm:text-7xl lg:text-[6rem]"
+          data-testid="one-message-headline"
+        >
+          {headline}
+        </h1>
+        {supportingText ? (
+          <p
+            className={cn(
+              'max-w-4xl text-2xl leading-relaxed text-slate-200 lg:text-3xl',
+              getClampClass(3),
+            )}
+            data-testid="one-message-supporting-text"
+          >
+            {supportingText}
+          </p>
+        ) : null}
+        {action ? (
+          <div
+            className="pt-2"
+            data-testid="one-message-action"
+          >
+            {action}
+          </div>
+        ) : null}
+      </div>
+      {media ? (
+        <div
+          className="flex min-h-[18rem] items-center justify-center overflow-hidden rounded-[1.75rem] border border-white/10 bg-white/5 p-6 lg:min-h-[24rem]"
+          data-testid="one-message-media"
+        >
+          {media}
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "skill-lint:report": "tsx tools/skills-lint/src/cli.ts report skills --out reports/skills",
     "skill-lint": "tsx tools/skills-lint/src/cli.ts lint",
     "storybook": "pnpm run serve:storybook",
+    "sync:registry": "node scripts/sync-shadcn-registry.mjs",
     "sync:skills": "node scripts/sync-skills.mjs",
     "test:affected": "nx affected --target=test",
     "test:all": "nx run-many --target=test --all",

--- a/scripts/sync-shadcn-registry.mjs
+++ b/scripts/sync-shadcn-registry.mjs
@@ -8,14 +8,36 @@ const registryDir = path.join(repoRoot, 'apps', 'client', 'public', 'registry');
 const registryIndexPath = path.join(registryDir, 'registry.json');
 
 const REGISTRY_ITEM_SCHEMA = 'https://ui.shadcn.com/schema/registry-item.json';
+const REGISTRY_ITEM_NAME_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/u;
 
 const readRegistryIndex = async () => {
   const fileContents = await readFile(registryIndexPath, 'utf8');
   return JSON.parse(fileContents);
 };
 
+const getValidatedRegistryItemName = (item) => {
+  const itemName = item?.name;
+
+  if (typeof itemName !== 'string' || itemName.length === 0) {
+    throw new Error('Registry item name must be a non-empty string.');
+  }
+
+  if (itemName === 'registry') {
+    throw new Error('Registry item name "registry" is reserved.');
+  }
+
+  if (!REGISTRY_ITEM_NAME_PATTERN.test(itemName)) {
+    throw new Error(
+      `Registry item name "${itemName}" must be kebab-case and contain only lowercase letters, numbers, and hyphens.`,
+    );
+  }
+
+  return itemName;
+};
+
 const writeRegistryItem = async (item) => {
-  const outputPath = path.join(registryDir, `${item.name}.json`);
+  const itemName = getValidatedRegistryItemName(item);
+  const outputPath = path.join(registryDir, `${itemName}.json`);
   const payload = {
     $schema: REGISTRY_ITEM_SCHEMA,
     ...item,
@@ -29,10 +51,9 @@ const syncRegistryItems = async () => {
 
   const registry = await readRegistryIndex();
   const items = Array.isArray(registry.items) ? registry.items : [];
+  const publishedItemNames = new Set(items.map((item) => getValidatedRegistryItemName(item)));
 
   await Promise.all(items.map((item) => writeRegistryItem(item)));
-
-  const publishedItemNames = new Set(items.map((item) => item.name));
   const directoryEntries = await readdir(registryDir);
 
   const staleArtifacts = directoryEntries

--- a/scripts/sync-shadcn-registry.mjs
+++ b/scripts/sync-shadcn-registry.mjs
@@ -1,0 +1,50 @@
+import { mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '..');
+const registryDir = path.join(repoRoot, 'apps', 'client', 'public', 'registry');
+const registryIndexPath = path.join(registryDir, 'registry.json');
+
+const REGISTRY_ITEM_SCHEMA = 'https://ui.shadcn.com/schema/registry-item.json';
+
+const readRegistryIndex = async () => {
+  const fileContents = await readFile(registryIndexPath, 'utf8');
+  return JSON.parse(fileContents);
+};
+
+const writeRegistryItem = async (item) => {
+  const outputPath = path.join(registryDir, `${item.name}.json`);
+  const payload = {
+    $schema: REGISTRY_ITEM_SCHEMA,
+    ...item,
+  };
+
+  await writeFile(outputPath, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+};
+
+const syncRegistryItems = async () => {
+  await mkdir(registryDir, { recursive: true });
+
+  const registry = await readRegistryIndex();
+  const items = Array.isArray(registry.items) ? registry.items : [];
+
+  await Promise.all(items.map((item) => writeRegistryItem(item)));
+
+  const publishedItemNames = new Set(items.map((item) => item.name));
+  const directoryEntries = await readdir(registryDir);
+
+  const staleArtifacts = directoryEntries
+    .filter((entry) => entry.endsWith('.json'))
+    .filter((entry) => entry !== 'registry.json')
+    .filter((entry) => !publishedItemNames.has(entry.replace(/\.json$/u, '')));
+
+  await Promise.all(
+    staleArtifacts.map((entry) => rm(path.join(registryDir, entry), { force: true })),
+  );
+
+  console.log(`Synced ${items.length} shadcn registry item files.`);
+};
+
+await syncRegistryItems();


### PR DESCRIPTION
## Summary

Add new signage fallback primitives and publish per-item shadcn registry endpoints so WallRun components install correctly.

## What Changed

- add new `shadcnui-signage` primitives for one-message, fallback, expiry, freshness, and reconnecting states
- export the new signage components from the library index
- add a registry sync script that generates per-item JSON files from the root registry index
- publish the generated registry item files under `apps/client/public/registry`
- update docs and install snippets to use per-item registry URLs for individual installs and keep the root index for `--all`
- expand the signage component gaps spec and supporting plans

## Validation

- `pnpm run sync:registry`
- `pnpm run type-check:client`
- focused `CodeSnippet` tests passed
