### PR TITLE
test(client): address remaining docs review nits

### DIFF
--- a/apps/client/src/app/pages/components/ComponentIndex.test.tsx
+++ b/apps/client/src/app/pages/components/ComponentIndex.test.tsx
@@ -5,7 +5,7 @@ import '@testing-library/jest-dom/vitest';
 import { ComponentIndexPage } from './ComponentIndex';
 
 describe('ComponentIndexPage', () => {
-  it('lists the new issue 98 docs entries in the browseable catalog', () => {
+  it('lists the new issue 98 docs entries in the browsable catalog', () => {
     render(
       <MemoryRouter>
         <ComponentIndexPage />

--- a/apps/client/src/app/pages/components/blocks/OneMessageFrameDoc.test.tsx
+++ b/apps/client/src/app/pages/components/blocks/OneMessageFrameDoc.test.tsx
@@ -25,9 +25,9 @@ describe('OneMessageFrameDocPage', () => {
     const storybookLink = screen.getByRole('link', {
       name: /view in storybook/i,
     });
-    const sourceLink = screen.getAllByRole('link', {
-      name: /view source/i,
-    })[1];
+    const sourceLink = screen.getByRole('link', {
+      name: /^view source$/i,
+    });
 
     expect(storybookLink).toHaveClass('h-11');
     expect(sourceLink).toHaveClass('h-11');


### PR DESCRIPTION
## Summary

This PR carries only the remaining post-merge review nits from the earlier Issue 98 docs work.

## What changed

- tighten the `OneMessageFrameDoc` test to avoid brittle indexed link selection
- fix the `ComponentIndex` test description spelling from `browseable` to `browsable`

## Files

- `apps/client/src/app/pages/components/blocks/OneMessageFrameDoc.test.tsx`
- `apps/client/src/app/pages/components/ComponentIndex.test.tsx`

## Verification

- focused `OneMessageFrameDoc.test.tsx` run passed earlier after the selector fix
- branch diff against `main` contains only the two test files above
