### PR TITLE
Improve component catalog discoverability and install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,12 @@ The signage components are distributed through a shadcn-compatible registry. Ins
 npx shadcn@latest add https://wallrun.dev/registry/auto-paging-list.json
 ```
 
+If you are installing into an already-configured monorepo workspace with its own `components.json`, target that workspace explicitly:
+
+```bash
+npx shadcn@latest add https://wallrun.dev/registry/all.json -c libs/common-ui
+```
+
 You can also browse the available components and installation options in:
 
 - [apps/client/public/registry/README.md](./apps/client/public/registry/README.md)

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ npx shadcn@latest add https://wallrun.dev/registry/auto-paging-list.json
 If you are installing into an already-configured monorepo workspace with its own `components.json`, target that workspace explicitly:
 
 ```bash
-npx shadcn@latest add https://wallrun.dev/registry/all.json -c libs/common-ui
+npx shadcn@latest add https://wallrun.dev/registry/all.json -c path/to/workspace
 ```
 
 You can also browse the available components and installation options in:

--- a/apps/client/public/library.md
+++ b/apps/client/public/library.md
@@ -42,6 +42,12 @@ npx shadcn@latest add https://wallrun.dev/registry/metric-card.json https://wall
 npx shadcn@latest add https://wallrun.dev/registry/all.json
 ```
 
+- Install everything into a configured monorepo workspace whose `components.json` lives under `libs/common-ui`:
+
+```bash
+npx shadcn@latest add https://wallrun.dev/registry/all.json -c libs/common-ui
+```
+
 Registry installs copy component code into the consuming application. They are not version-locked runtime packages.
 
 For discovery with the latest CLI, query the registry index directly:

--- a/apps/client/public/library.md
+++ b/apps/client/public/library.md
@@ -42,10 +42,10 @@ npx shadcn@latest add https://wallrun.dev/registry/metric-card.json https://wall
 npx shadcn@latest add https://wallrun.dev/registry/all.json
 ```
 
-- Install everything into a configured monorepo workspace whose `components.json` lives under `libs/common-ui`:
+- Install everything into a configured monorepo workspace by passing the directory that contains your `components.json`:
 
 ```bash
-npx shadcn@latest add https://wallrun.dev/registry/all.json -c libs/common-ui
+npx shadcn@latest add https://wallrun.dev/registry/all.json -c path/to/workspace
 ```
 
 Registry installs copy component code into the consuming application. They are not version-locked runtime packages.

--- a/apps/client/public/registry/README.md
+++ b/apps/client/public/registry/README.md
@@ -30,10 +30,10 @@ Install the whole registry only when you really want everything:
 npx shadcn@latest add https://wallrun.dev/registry/all.json
 ```
 
-If your repo is a monorepo and the target `components.json` is not at the repo root, point the CLI at the configured workspace explicitly:
+If your repo is a monorepo and the target `components.json` is not at the repo root, point the CLI at the workspace that contains that file:
 
 ```bash
-npx shadcn@latest add https://wallrun.dev/registry/all.json -c libs/common-ui
+npx shadcn@latest add https://wallrun.dev/registry/all.json -c path/to/workspace
 ```
 
 `registry.json` is the registry index for discovery and namespaced resolution. Direct URL installs must target an installable item payload such as `all.json` or `metric-card.json`.

--- a/apps/client/public/registry/README.md
+++ b/apps/client/public/registry/README.md
@@ -30,6 +30,12 @@ Install the whole registry only when you really want everything:
 npx shadcn@latest add https://wallrun.dev/registry/all.json
 ```
 
+If your repo is a monorepo and the target `components.json` is not at the repo root, point the CLI at the configured workspace explicitly:
+
+```bash
+npx shadcn@latest add https://wallrun.dev/registry/all.json -c libs/common-ui
+```
+
 `registry.json` is the registry index for discovery and namespaced resolution. Direct URL installs must target an installable item payload such as `all.json` or `metric-card.json`.
 
 To browse what is available with the latest CLI, search the registry index directly:

--- a/apps/client/src/app/components/CodeSnippet.test.tsx
+++ b/apps/client/src/app/components/CodeSnippet.test.tsx
@@ -6,7 +6,6 @@ import {
   getPublicRegistryAllUrl,
   getPublicRegistryItemUrl,
   LEGACY_REGISTRY_URL,
-  PUBLIC_REGISTRY_URL,
 } from './componentDocs.constants';
 
 describe('CodeSnippet', () => {

--- a/apps/client/src/app/pages/components/ComponentIndex.test.tsx
+++ b/apps/client/src/app/pages/components/ComponentIndex.test.tsx
@@ -5,12 +5,16 @@ import '@testing-library/jest-dom/vitest';
 import { ComponentIndexPage } from './ComponentIndex';
 
 describe('ComponentIndexPage', () => {
-  it('lists the new issue 98 docs entries in the browsable catalog', () => {
+  const renderWithRouter = (initialEntries = ['/components']) => {
     render(
-      <MemoryRouter>
+      <MemoryRouter initialEntries={initialEntries}>
         <ComponentIndexPage />
       </MemoryRouter>,
     );
+  };
+
+  it('lists the new issue 98 docs entries in the browsable catalog', () => {
+    renderWithRouter();
 
     expect(
       screen.getByRole('link', { name: /OneMessageFrame/i }),
@@ -27,5 +31,44 @@ describe('ComponentIndexPage', () => {
     expect(
       screen.getByRole('link', { name: /ReconnectingState/i }),
     ).toHaveAttribute('href', '/components/behaviour/reconnecting-state');
+  });
+
+  it('renders search and browse-by-use-case controls', () => {
+    renderWithRouter();
+
+    expect(
+      screen.getByRole('searchbox', { name: /search components/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: /browse by use case/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('use-case-card-menu-boards'),
+    ).toBeInTheDocument();
+  });
+
+  it('filters the catalog from the useCase query param', () => {
+    renderWithRouter(['/components?useCase=Alerts']);
+
+    expect(
+      screen.getByText(/showing 13 matching components\./i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: /OfflineFallback/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', { name: /MenuItem/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('filters the catalog from the text query param', () => {
+    renderWithRouter(['/components?q=offline']);
+
+    expect(
+      screen.getByRole('link', { name: /OfflineFallback/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', { name: /Clock/i }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/apps/client/src/app/pages/components/ComponentIndex.test.tsx
+++ b/apps/client/src/app/pages/components/ComponentIndex.test.tsx
@@ -51,7 +51,7 @@ describe('ComponentIndexPage', () => {
     renderWithRouter(['/components?useCase=Alerts']);
 
     expect(
-      screen.getByText(/showing 13 matching components\./i),
+      screen.getByText(/showing \d+ matching components\./i),
     ).toBeInTheDocument();
     expect(
       screen.getByRole('link', { name: /OfflineFallback/i }),

--- a/apps/client/src/app/pages/components/ComponentIndex.tsx
+++ b/apps/client/src/app/pages/components/ComponentIndex.tsx
@@ -1,22 +1,50 @@
 import { FC } from 'react';
-import { Link } from 'react-router-dom';
-import { Badge } from '@wallrun/shadcnui';
-import { Activity, Box, Layout, Layers } from 'lucide-react';
+import { Link, useSearchParams } from 'react-router-dom';
+import { Badge, Button, Input } from '@wallrun/shadcnui';
+import { Activity, Box, Compass, Layout, Layers, Search } from 'lucide-react';
 
-interface ComponentInfo {
+const componentCategories = [
+  'Primitives',
+  'Layouts',
+  'Blocks',
+  'Behaviour',
+] as const;
+
+const componentUseCases = [
+  'Menu Boards',
+  'Wayfinding',
+  'Dashboards',
+  'Schedules',
+  'Alerts',
+  'Room Signage',
+  'Phone Handoff',
+] as const;
+
+type ComponentCategory = (typeof componentCategories)[number];
+type ComponentUseCase = (typeof componentUseCases)[number];
+
+type ComponentInfo = {
   name: string;
   path: string;
   description: string;
-  category: 'Primitives' | 'Layouts' | 'Blocks' | 'Behaviour';
-}
+  category: ComponentCategory;
+  keywords: string[];
+  useCases: ComponentUseCase[];
+};
+
+type CategorySection = {
+  category: ComponentCategory;
+  description: string;
+};
 
 const components: ComponentInfo[] = [
-  // Primitives
   {
     name: 'ScreenFrame',
     path: '/components/primitives/screen-frame',
     description: 'Base frame for signage content with fixed aspect ratios',
     category: 'Primitives',
+    keywords: ['frame', 'aspect ratio', 'fullscreen', 'canvas'],
+    useCases: ['Dashboards', 'Room Signage'],
   },
   {
     name: 'MetricCard',
@@ -24,91 +52,120 @@ const components: ComponentInfo[] = [
     description:
       'Display KPIs and metrics with value, change indicators, and icons',
     category: 'Primitives',
+    keywords: ['kpi', 'metric', 'stats', 'analytics'],
+    useCases: ['Dashboards'],
   },
   {
     name: 'EventCard',
     path: '/components/primitives/event-card',
     description: 'Event information cards with date, time, and location',
     category: 'Primitives',
+    keywords: ['event', 'schedule', 'agenda', 'listing'],
+    useCases: ['Schedules', 'Room Signage'],
   },
   {
     name: 'AnnouncementCard',
     path: '/components/primitives/announcement-card',
     description: 'Announcement cards for important messages and updates',
     category: 'Primitives',
+    keywords: ['notice', 'announcement', 'message', 'update'],
+    useCases: ['Alerts', 'Room Signage'],
   },
   {
     name: 'DirectoryCard',
     path: '/components/primitives/directory-card',
     description: 'Wayfinding card for departments, floors, rooms, and contacts',
     category: 'Primitives',
+    keywords: ['directory', 'map', 'departments', 'rooms'],
+    useCases: ['Wayfinding'],
   },
   {
     name: 'FloorBadge',
     path: '/components/primitives/floor-badge',
     description: 'Compact floor marker for directories, maps, and wayfinding',
     category: 'Primitives',
+    keywords: ['floor', 'level', 'label', 'wayfinding'],
+    useCases: ['Wayfinding'],
   },
   {
     name: 'LocationIndicator',
     path: '/components/primitives/location-indicator',
     description: 'Current-location chip for wayfinding and directory headers',
     category: 'Primitives',
+    keywords: ['location', 'current', 'header', 'wayfinding'],
+    useCases: ['Wayfinding', 'Room Signage'],
   },
   {
     name: 'MenuItem',
     path: '/components/primitives/menu-item',
     description: 'Price-led menu row with optional description and divider',
     category: 'Primitives',
+    keywords: ['menu', 'price', 'food', 'item'],
+    useCases: ['Menu Boards'],
   },
   {
     name: 'MenuSection',
     path: '/components/primitives/menu-section',
     description: 'Section wrapper for grouped menu content and headings',
     category: 'Primitives',
+    keywords: ['menu', 'section', 'category', 'food'],
+    useCases: ['Menu Boards'],
   },
   {
     name: 'SignagePanel',
     path: '/components/primitives/signage-panel',
     description: 'Bordered panel for grouped supporting information',
     category: 'Primitives',
+    keywords: ['panel', 'supporting info', 'group', 'container'],
+    useCases: ['Dashboards', 'Room Signage'],
   },
   {
     name: 'MeetingRow',
     path: '/components/primitives/meeting-row',
     description: 'Agenda row for meeting schedules and room bookings',
     category: 'Primitives',
+    keywords: ['meeting', 'booking', 'agenda', 'room'],
+    useCases: ['Schedules', 'Room Signage'],
   },
   {
     name: 'InfoList',
     path: '/components/primitives/info-list',
     description: 'Large-format list for instructions and operational notes',
     category: 'Primitives',
+    keywords: ['instructions', 'operations', 'notes', 'list'],
+    useCases: ['Alerts', 'Room Signage'],
   },
   {
     name: 'ActionStrip',
     path: '/components/primitives/action-strip',
     description: 'Reusable CTA shell for footer strips and side-zone actions',
     category: 'Primitives',
+    keywords: ['cta', 'actions', 'footer', 'handoff'],
+    useCases: ['Phone Handoff', 'Alerts'],
   },
   {
     name: 'ShortUrlCallout',
     path: '/components/primitives/short-url-callout',
     description: 'Readable manual fallback URL for QR and phone handoff flows',
     category: 'Primitives',
+    keywords: ['url', 'mobile', 'handoff', 'fallback'],
+    useCases: ['Phone Handoff'],
   },
   {
     name: 'QRCodeCallout',
     path: '/components/primitives/qr-code-callout',
     description: 'Scan-safe QR surface with destination context and URL fallback',
     category: 'Primitives',
+    keywords: ['qr', 'scan', 'mobile', 'handoff'],
+    useCases: ['Phone Handoff'],
   },
-  // Layouts
   {
     name: 'SplitScreen',
     path: '/components/layouts/split-screen',
     description: 'Two-panel layouts with configurable split ratios',
     category: 'Layouts',
+    keywords: ['split', 'two-panel', 'layout', 'zones'],
+    useCases: ['Dashboards', 'Room Signage'],
   },
   {
     name: 'SignageContainer',
@@ -116,50 +173,65 @@ const components: ComponentInfo[] = [
     description:
       'Full-screen container with ambient effects and gradient backgrounds',
     category: 'Layouts',
+    keywords: ['fullscreen', 'container', 'background', 'canvas'],
+    useCases: ['Dashboards', 'Alerts', 'Room Signage'],
   },
   {
     name: 'SignageHeader',
     path: '/components/layouts/signage-header',
     description: 'Standard signage header with logo, title, and metadata',
     category: 'Layouts',
+    keywords: ['header', 'metadata', 'branding', 'title'],
+    useCases: ['Dashboards', 'Room Signage', 'Wayfinding'],
   },
-  // Blocks
   {
     name: 'FullscreenHero',
     path: '/components/blocks/fullscreen-hero',
     description: 'Hero sections optimized for full-screen signage displays',
     category: 'Blocks',
+    keywords: ['hero', 'headline', 'fullscreen', 'message'],
+    useCases: ['Alerts', 'Room Signage'],
   },
   {
     name: 'OneMessageFrame',
     path: '/components/blocks/one-message-frame',
-    description: 'Single-message shell for dominant notices and interruption states',
+    description:
+      'Single-message shell for dominant notices and interruption states',
     category: 'Blocks',
+    keywords: ['single message', 'interrupt', 'notice', 'alert'],
+    useCases: ['Alerts'],
   },
   {
     name: 'InfoCardGrid',
     path: '/components/blocks/info-card-grid',
     description: 'Grid layouts for displaying multiple information cards',
     category: 'Blocks',
+    keywords: ['grid', 'cards', 'overview', 'kpi'],
+    useCases: ['Dashboards', 'Room Signage'],
   },
   {
     name: 'MenuBoard',
     path: '/components/blocks/menu-board',
     description: 'Full-screen composition shell for menu boards and daypart content',
     category: 'Blocks',
+    keywords: ['menu', 'board', 'daypart', 'food'],
+    useCases: ['Menu Boards'],
   },
   {
     name: 'QRHandoff',
     path: '/components/blocks/qr-handoff',
     description: 'Composed phone-handoff surface for QR continuation flows',
     category: 'Blocks',
+    keywords: ['qr', 'mobile', 'handoff', 'continuation'],
+    useCases: ['Phone Handoff'],
   },
-  // Behaviour
   {
     name: 'ContentExpiredWarning',
     path: '/components/behaviour/content-expired-warning',
     description: 'Expiration marker for preview, QA, and operator contexts',
     category: 'Behaviour',
+    keywords: ['expired', 'warning', 'qa', 'operator'],
+    useCases: ['Alerts'],
   },
   {
     name: 'ContentRotator',
@@ -167,6 +239,8 @@ const components: ComponentInfo[] = [
     description:
       'Rotate content on a fixed cadence with signage-safe transitions',
     category: 'Behaviour',
+    keywords: ['rotation', 'playlist', 'cadence', 'loop'],
+    useCases: ['Dashboards', 'Alerts'],
   },
   {
     name: 'ScheduleGate',
@@ -174,12 +248,16 @@ const components: ComponentInfo[] = [
     description:
       'Time/day gating (optionally timezone-aware) for daypart content',
     category: 'Behaviour',
+    keywords: ['schedule', 'daypart', 'timezone', 'gate'],
+    useCases: ['Schedules', 'Menu Boards'],
   },
   {
     name: 'AutoPagingList',
     path: '/components/behaviour/auto-paging-list',
     description: 'Paged lists (no scrolling) with dwell time per page',
     category: 'Behaviour',
+    keywords: ['paging', 'lists', 'dwell time', 'rotation'],
+    useCases: ['Schedules', 'Dashboards'],
   },
   {
     name: 'SignageTransition',
@@ -187,12 +265,16 @@ const components: ComponentInfo[] = [
     description:
       'Predictable transitions (crossfade/slide) with reduced-motion support',
     category: 'Behaviour',
+    keywords: ['transition', 'crossfade', 'slide', 'motion'],
+    useCases: ['Dashboards', 'Alerts'],
   },
   {
     name: 'Clock',
     path: '/components/behaviour/clock',
     description: 'Signage-friendly clock with optional timezone and seconds',
     category: 'Behaviour',
+    keywords: ['clock', 'time', 'timezone', 'live'],
+    useCases: ['Schedules', 'Room Signage'],
   },
   {
     name: 'Countdown',
@@ -200,39 +282,90 @@ const components: ComponentInfo[] = [
     description:
       'Countdown to an epoch time with clamping and completion callback',
     category: 'Behaviour',
+    keywords: ['countdown', 'timer', 'deadline', 'event'],
+    useCases: ['Schedules', 'Alerts'],
   },
   {
     name: 'LastUpdatedStamp',
     path: '/components/behaviour/last-updated-stamp',
     description: 'Quiet freshness stamp for live-data screens and fallback states',
     category: 'Behaviour',
+    keywords: ['freshness', 'timestamp', 'live data', 'updated'],
+    useCases: ['Dashboards'],
   },
   {
     name: 'NoContentFallback',
     path: '/components/behaviour/no-content-fallback',
     description: 'Fallback surface for feeds, schedules, and playlists with no valid content',
     category: 'Behaviour',
+    keywords: ['fallback', 'empty state', 'content', 'playlist'],
+    useCases: ['Alerts', 'Schedules'],
   },
   {
     name: 'OfflineFallback',
     path: '/components/behaviour/offline-fallback',
-    description:
-      'Stable fallback boundary for offline/unhealthy networked content',
+    description: 'Stable fallback boundary for offline/unhealthy networked content',
     category: 'Behaviour',
+    keywords: ['offline', 'network', 'fallback', 'reliability'],
+    useCases: ['Alerts', 'Dashboards'],
   },
   {
     name: 'ReconnectingState',
     path: '/components/behaviour/reconnecting-state',
     description: 'Recovery-state notice for live regions restoring service',
     category: 'Behaviour',
+    keywords: ['reconnecting', 'recovery', 'network', 'status'],
+    useCases: ['Alerts', 'Dashboards'],
   },
   {
     name: 'StaleDataIndicator',
     path: '/components/behaviour/stale-data-indicator',
     description: 'Compact freshness indicator for always-on screens',
     category: 'Behaviour',
+    keywords: ['stale', 'data', 'freshness', 'status'],
+    useCases: ['Dashboards'],
   },
 ];
+
+const categorySections: CategorySection[] = [
+  {
+    category: 'Primitives',
+    description:
+      'Basic building blocks for signage content. Cards, frames, and display elements optimized for distance viewing.',
+  },
+  {
+    category: 'Layouts',
+    description:
+      'Structural components for organizing signage screens. Containers, headers, and split-screen layouts.',
+  },
+  {
+    category: 'Blocks',
+    description:
+      'Higher-level composed components combining primitives and layouts into complete sections.',
+  },
+  {
+    category: 'Behaviour',
+    description:
+      'Time, rotation, transitions, and screen-safe runtime behaviour for always-on signage.',
+  },
+];
+
+const useCaseDescriptions: Record<ComponentUseCase, string> = {
+  'Menu Boards':
+    'Price-led menu surfaces, daypart gating, and full-screen menu compositions.',
+  Wayfinding:
+    'Directories, floor labels, and current-location context for navigation screens.',
+  Dashboards:
+    'KPI surfaces, freshness states, and multi-zone overview layouts.',
+  Schedules:
+    'Events, meetings, clocks, countdowns, and time-aware lists.',
+  Alerts:
+    'High-priority messages, interruption states, and resilient fallback surfaces.',
+  'Room Signage':
+    'Meeting room, lobby, and venue displays with identity and schedule context.',
+  'Phone Handoff':
+    'QR, short URL, and call-to-action patterns that shift the task to mobile.',
+};
 
 const categoryIcons = {
   Primitives: Box,
@@ -248,23 +381,94 @@ const categoryColors = {
   Behaviour: 'bg-amber-500/10 text-amber-500 border-amber-500/20',
 };
 
+const slugify = (value: string) => value.toLowerCase().replace(/\s+/g, '-');
+
+const matchesQuery = (component: ComponentInfo, query: string) => {
+  if (!query.trim()) {
+    return true;
+  }
+
+  const haystack = [
+    component.name,
+    component.description,
+    component.category,
+    ...component.keywords,
+    ...component.useCases,
+  ]
+    .join(' ')
+    .toLowerCase();
+
+  return haystack.includes(query.toLowerCase().trim());
+};
+
+const useCaseCount = (useCase: ComponentUseCase) =>
+  components.filter((component) => component.useCases.includes(useCase)).length;
+
 export const ComponentIndexPage: FC = () => {
-  const primitives = components.filter((c) => c.category === 'Primitives');
-  const layouts = components.filter((c) => c.category === 'Layouts');
-  const blocks = components.filter((c) => c.category === 'Blocks');
-  const behaviour = components.filter((c) => c.category === 'Behaviour');
+  const [searchParams, setSearchParams] = useSearchParams();
+  const searchQuery = searchParams.get('q') ?? '';
+  const selectedCategory = componentCategories.find(
+    (category) => category === searchParams.get('category'),
+  );
+  const selectedUseCase = componentUseCases.find(
+    (useCase) => useCase === searchParams.get('useCase'),
+  );
+
+  const updateFilters = (
+    updates: Partial<Record<'q' | 'category' | 'useCase', string | null>>,
+  ) => {
+    const nextParams = new URLSearchParams(searchParams);
+
+    Object.entries(updates).forEach(([key, value]) => {
+      if (!value) {
+        nextParams.delete(key);
+        return;
+      }
+
+      nextParams.set(key, value);
+    });
+
+    setSearchParams(nextParams, { replace: true });
+  };
+
+  const filteredComponents = components.filter((component) => {
+    if (selectedCategory && component.category !== selectedCategory) {
+      return false;
+    }
+
+    if (selectedUseCase && !component.useCases.includes(selectedUseCase)) {
+      return false;
+    }
+
+    return matchesQuery(component, searchQuery);
+  });
+
+  const visibleSections = categorySections
+    .map((section) => ({
+      ...section,
+      components: filteredComponents.filter(
+        (component) => component.category === section.category,
+      ),
+      totalCount: components.filter(
+        (component) => component.category === section.category,
+      ).length,
+    }))
+    .filter((section) => section.components.length > 0);
+
+  const hasActiveFilters = Boolean(
+    searchQuery || selectedCategory || selectedUseCase,
+  );
 
   return (
     <div className="container mx-auto px-4 py-8" data-testid="component-index">
-      {/* Header */}
       <div className="mb-10 space-y-4">
         <p className="text-sm text-muted-foreground">Documentation</p>
 
-        <h1 className="text-3xl md:text-4xl font-medium tracking-tight">
+        <h1 className="text-3xl font-medium tracking-tight md:text-4xl">
           Signage Components
         </h1>
 
-        <p className="max-w-2xl text-base md:text-lg text-muted-foreground">
+        <p className="max-w-2xl text-base text-muted-foreground md:text-lg">
           React components for digital signage displays. Built on{' '}
           <a
             href="https://ui.shadcn.com"
@@ -279,9 +483,8 @@ export const ComponentIndexPage: FC = () => {
         </p>
       </div>
 
-      {/* Overview */}
       <section className="mb-12">
-        <h2 className="text-2xl font-medium mb-6">What is shadcnui-signage?</h2>
+        <h2 className="mb-6 text-2xl font-medium">What is shadcnui-signage?</h2>
         <div className="space-y-4 text-muted-foreground">
           <p>
             <strong className="text-foreground">shadcnui-signage</strong> is a
@@ -289,7 +492,7 @@ export const ComponentIndexPage: FC = () => {
             signage applications. Unlike standard web UI components, these are
             optimized for:
           </p>
-          <ul className="list-disc list-inside space-y-2 ml-4">
+          <ul className="ml-4 list-inside list-disc space-y-2">
             <li>
               <strong className="text-foreground">Distance readability</strong>{' '}
               - Large typography and high contrast for 10+ foot viewing
@@ -303,110 +506,230 @@ export const ComponentIndexPage: FC = () => {
               - Performance and stability for 24/7 operation
             </li>
             <li>
-              <strong className="text-foreground">
-                Offline-first operation
-              </strong>{' '}
+              <strong className="text-foreground">Offline-first operation</strong>{' '}
               - Works reliably on BrightSign and similar devices
             </li>
           </ul>
           <p>
             Each component builds on shadcn/ui primitives, extending them with
             signage-specific constraints and behaviors. This is not a parallel
-            design system—it's a signage-focused extension of shadcn/ui.
+            design system - it is a signage-focused extension of shadcn/ui.
           </p>
         </div>
       </section>
 
-      {/* Component Categories */}
+      <section className="demo-panel mb-12 space-y-6 p-6 sm:p-8">
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+          <div className="space-y-2">
+            <p className="text-sm text-muted-foreground">Find the right building block</p>
+            <h2 className="text-2xl font-medium text-foreground">
+              Search by problem, not just by category
+            </h2>
+            <p className="max-w-2xl text-sm text-muted-foreground">
+              Search by component name, screen pattern, or implementation clue,
+              then narrow the catalog by category or use case.
+            </p>
+          </div>
+          <Badge variant="outline" className="w-fit px-3 py-1 text-sm">
+            {filteredComponents.length} of {components.length} visible
+          </Badge>
+        </div>
+
+        <div className="grid gap-6 lg:grid-cols-[minmax(0,1.4fr)_minmax(0,1fr)]">
+          <div className="space-y-3">
+            <label
+              htmlFor="component-search"
+              className="text-sm font-medium text-foreground"
+            >
+              Search components
+            </label>
+            <div className="relative">
+              <Search
+                className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+                aria-hidden="true"
+              />
+              <Input
+                id="component-search"
+                type="search"
+                value={searchQuery}
+                onChange={(event) =>
+                  updateFilters({ q: event.target.value || null })
+                }
+                placeholder="Search by name, keyword, or use case"
+                className="h-11 pl-10"
+              />
+            </div>
+          </div>
+
+          <div className="space-y-3">
+            <p className="text-sm font-medium text-foreground">Category</p>
+            <div className="flex flex-wrap gap-2">
+              <FilterButton
+                isActive={!selectedCategory}
+                onClick={() => updateFilters({ category: null })}
+              >
+                All categories
+              </FilterButton>
+              {componentCategories.map((category) => (
+                <FilterButton
+                  key={category}
+                  isActive={selectedCategory === category}
+                  onClick={() =>
+                    updateFilters({
+                      category: selectedCategory === category ? null : category,
+                    })
+                  }
+                >
+                  {category}
+                </FilterButton>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        <div className="space-y-3 border-t border-border pt-6">
+          <p className="text-sm font-medium text-foreground">Use case</p>
+          <div className="flex flex-wrap gap-2">
+            <FilterButton
+              isActive={!selectedUseCase}
+              onClick={() => updateFilters({ useCase: null })}
+            >
+              All use cases
+            </FilterButton>
+            {componentUseCases.map((useCase) => (
+              <FilterButton
+                key={useCase}
+                isActive={selectedUseCase === useCase}
+                onClick={() =>
+                  updateFilters({
+                    useCase: selectedUseCase === useCase ? null : useCase,
+                  })
+                }
+              >
+                {useCase}
+              </FilterButton>
+            ))}
+          </div>
+        </div>
+
+        <div className="flex flex-wrap items-center justify-between gap-3 border-t border-border pt-6 text-sm text-muted-foreground">
+          <p>
+            Showing {filteredComponents.length} matching component
+            {filteredComponents.length === 1 ? '' : 's'}.
+          </p>
+          {hasActiveFilters ? (
+            <Button
+              type="button"
+              variant="ghost"
+              className="h-10 px-3"
+              onClick={() =>
+                updateFilters({ q: null, category: null, useCase: null })
+              }
+            >
+              Clear filters
+            </Button>
+          ) : null}
+        </div>
+      </section>
+
+      <section className="mb-12 space-y-6">
+        <div className="space-y-2">
+          <div className="flex items-center gap-3">
+            <Compass className="h-5 w-5 text-foreground" aria-hidden="true" />
+            <h2 className="text-2xl font-medium">Browse by use case</h2>
+          </div>
+          <p className="max-w-2xl text-sm text-muted-foreground">
+            Start from the screen you are trying to build. Each path narrows the
+            library to components that tend to work together.
+          </p>
+        </div>
+
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+          {componentUseCases.map((useCase) => {
+            const isActive = selectedUseCase === useCase;
+
+            return (
+              <button
+                key={useCase}
+                type="button"
+                aria-pressed={isActive}
+                onClick={() =>
+                  updateFilters({ useCase: isActive ? null : useCase })
+                }
+                className="group rounded-lg border border-border bg-card/40 p-5 text-left transition-colors hover:border-foreground/40 hover:bg-muted/40"
+                data-testid={`use-case-card-${slugify(useCase)}`}
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div className="space-y-2">
+                    <h3 className="text-lg font-medium text-foreground">
+                      {useCase}
+                    </h3>
+                    <p className="text-sm text-muted-foreground">
+                      {useCaseDescriptions[useCase]}
+                    </p>
+                  </div>
+                  <Badge variant="outline" className="shrink-0">
+                    {useCaseCount(useCase)}
+                  </Badge>
+                </div>
+              </button>
+            );
+          })}
+        </div>
+      </section>
+
       <section className="space-y-12">
-        {/* Primitives */}
-        <div>
-          <div className="flex items-center gap-3 mb-6">
-            <Box className="w-6 h-6 text-blue-500" />
-            <h2 className="text-2xl font-medium">Primitives</h2>
-            <Badge variant="outline" className={categoryColors.Primitives}>
-              {primitives.length} components
-            </Badge>
-          </div>
-          <p className="text-muted-foreground mb-6">
-            Basic building blocks for signage content. Cards, frames, and
-            display elements optimized for distance viewing.
-          </p>
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            {primitives.map((component) => (
-              <ComponentCard key={component.name} component={component} />
-            ))}
-          </div>
-        </div>
+        {visibleSections.length > 0 ? (
+          visibleSections.map((section) => {
+            const Icon = categoryIcons[section.category];
 
-        {/* Layouts */}
-        <div>
-          <div className="flex items-center gap-3 mb-6">
-            <Layout className="w-6 h-6 text-green-500" />
-            <h2 className="text-2xl font-medium">Layouts</h2>
-            <Badge variant="outline" className={categoryColors.Layouts}>
-              {layouts.length} components
-            </Badge>
+            return (
+              <div key={section.category}>
+                <div className="mb-6 flex flex-wrap items-center gap-3">
+                  <Icon className="h-6 w-6" aria-hidden="true" />
+                  <h2 className="text-2xl font-medium">{section.category}</h2>
+                  <Badge variant="outline" className={categoryColors[section.category]}>
+                    {section.components.length} of {section.totalCount}
+                  </Badge>
+                </div>
+                <p className="mb-6 text-muted-foreground">{section.description}</p>
+                <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                  {section.components.map((component) => (
+                    <ComponentCard key={component.name} component={component} />
+                  ))}
+                </div>
+              </div>
+            );
+          })
+        ) : (
+          <div className="demo-panel-soft rounded-lg border border-dashed border-border px-6 py-10 text-center">
+            <h2 className="text-xl font-medium text-foreground">No matching components</h2>
+            <p className="mx-auto mt-3 max-w-xl text-sm text-muted-foreground">
+              Try a broader search term or clear one of the active filters. The
+              current catalog is indexed by name, description, keywords, and use case.
+            </p>
+            {hasActiveFilters ? (
+              <Button
+                type="button"
+                variant="secondary"
+                className="mt-5 h-11 px-4"
+                onClick={() =>
+                  updateFilters({ q: null, category: null, useCase: null })
+                }
+              >
+                Reset discoverability filters
+              </Button>
+            ) : null}
           </div>
-          <p className="text-muted-foreground mb-6">
-            Structural components for organizing signage screens. Containers,
-            headers, and split-screen layouts.
-          </p>
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            {layouts.map((component) => (
-              <ComponentCard key={component.name} component={component} />
-            ))}
-          </div>
-        </div>
-
-        {/* Blocks */}
-        <div>
-          <div className="flex items-center gap-3 mb-6">
-            <Layers className="w-6 h-6 text-purple-500" />
-            <h2 className="text-2xl font-medium">Blocks</h2>
-            <Badge variant="outline" className={categoryColors.Blocks}>
-              {blocks.length} components
-            </Badge>
-          </div>
-          <p className="text-muted-foreground mb-6">
-            Higher-level composed components combining primitives and layouts
-            into complete sections.
-          </p>
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            {blocks.map((component) => (
-              <ComponentCard key={component.name} component={component} />
-            ))}
-          </div>
-        </div>
-
-        {/* Behaviour */}
-        <div>
-          <div className="flex items-center gap-3 mb-6">
-            <Activity className="w-6 h-6 text-amber-500" />
-            <h2 className="text-2xl font-medium">Behaviour</h2>
-            <Badge variant="outline" className={categoryColors.Behaviour}>
-              {behaviour.length} components
-            </Badge>
-          </div>
-          <p className="text-muted-foreground mb-6">
-            Time, rotation, transitions, and screen-safe runtime behaviour for
-            always-on signage.
-          </p>
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            {behaviour.map((component) => (
-              <ComponentCard key={component.name} component={component} />
-            ))}
-          </div>
-        </div>
+        )}
       </section>
 
-      {/* Footer */}
-      <footer className="mt-16 pt-8 border-t border-border">
+      <footer className="mt-16 border-t border-border pt-8">
         <div className="space-y-4 text-sm text-muted-foreground">
           <p>
             <strong className="text-foreground">Installation:</strong> All
             components are available via the{' '}
-            <code className="bg-muted px-2 py-1 rounded">
+            <code className="rounded bg-muted px-2 py-1">
               @wallrun/shadcnui-signage
             </code>{' '}
             package.
@@ -436,26 +759,61 @@ export const ComponentIndexPage: FC = () => {
   );
 };
 
+const FilterButton: FC<{
+  children: string;
+  isActive: boolean;
+  onClick: () => void;
+}> = ({ children, isActive, onClick }) => (
+  <Button
+    type="button"
+    variant={isActive ? 'secondary' : 'outline'}
+    className="h-10 rounded-full px-4"
+    aria-pressed={isActive}
+    onClick={onClick}
+  >
+    {children}
+  </Button>
+);
+
 const ComponentCard: FC<{ component: ComponentInfo }> = ({ component }) => {
   const Icon = categoryIcons[component.category];
 
   return (
     <Link
       to={component.path}
-      className="block p-6 border border-border rounded-lg hover:border-foreground/50 hover:bg-muted/50 transition-colors group"
+      className="group block rounded-lg border border-border p-6 transition-colors hover:border-foreground/50 hover:bg-muted/50"
       data-testid={`component-card-${component.name}`}
     >
       <div className="flex items-start gap-4">
-        <div className={`p-2 rounded ${categoryColors[component.category]}`}>
-          <Icon className="w-5 h-5" />
+        <div className={`rounded p-2 ${categoryColors[component.category]}`}>
+          <Icon className="h-5 w-5" aria-hidden="true" />
         </div>
-        <div className="flex-1 min-w-0">
-          <h3 className="text-lg font-medium mb-2 group-hover:text-foreground">
-            {component.name}
-          </h3>
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <h3 className="mb-2 text-lg font-medium text-foreground">
+              {component.name}
+            </h3>
+            <Badge
+              variant="outline"
+              className="mb-2 text-[11px] uppercase tracking-[0.18em]"
+            >
+              {component.category}
+            </Badge>
+          </div>
           <p className="text-sm text-muted-foreground">
             {component.description}
           </p>
+          <div className="mt-4 flex flex-wrap gap-2">
+            {component.useCases.slice(0, 2).map((useCase) => (
+              <Badge
+                key={`${component.name}-${useCase}`}
+                variant="outline"
+                className="text-[11px] text-muted-foreground"
+              >
+                {useCase}
+              </Badge>
+            ))}
+          </div>
         </div>
       </div>
     </Link>

--- a/apps/client/src/app/pages/components/ComponentIndex.tsx
+++ b/apps/client/src/app/pages/components/ComponentIndex.tsx
@@ -401,7 +401,7 @@ const matchesQuery = (component: ComponentInfo, query: string) => {
   return haystack.includes(query.toLowerCase().trim());
 };
 
-const useCaseCount = (useCase: ComponentUseCase) =>
+const getUseCaseCount = (useCase: ComponentUseCase) =>
   components.filter((component) => component.useCases.includes(useCase)).length;
 
 export const ComponentIndexPage: FC = () => {
@@ -669,7 +669,7 @@ export const ComponentIndexPage: FC = () => {
                     </p>
                   </div>
                   <Badge variant="outline" className="shrink-0">
-                    {useCaseCount(useCase)}
+                    {getUseCaseCount(useCase)}
                   </Badge>
                 </div>
               </button>

--- a/libs/shell/src/lib/layouts/Layout.tsx
+++ b/libs/shell/src/lib/layouts/Layout.tsx
@@ -12,10 +12,9 @@ import {
   SidebarTrigger,
 } from '@wallrun/shadcnui';
 import { AppSidebar } from './AppSidebar';
-import { Fragment, ReactNode } from 'react';
+import { Fragment, ReactNode, useEffect, useState } from 'react';
 import { Moon, Sun, Github } from 'lucide-react';
 import { useLocation, Link } from 'react-router-dom';
-import { useState, useEffect } from 'react';
 import {
   SidebarProvider as SidebarDataProvider,
   SidebarData,

--- a/libs/shell/src/lib/layouts/Layout.tsx
+++ b/libs/shell/src/lib/layouts/Layout.tsx
@@ -12,7 +12,7 @@ import {
   SidebarTrigger,
 } from '@wallrun/shadcnui';
 import { AppSidebar } from './AppSidebar';
-import { ReactNode } from 'react';
+import { Fragment, ReactNode } from 'react';
 import { Moon, Sun, Github } from 'lucide-react';
 import { useLocation, Link } from 'react-router-dom';
 import { useState, useEffect } from 'react';
@@ -77,30 +77,31 @@ export function Layout({ children, sidebarData }: LayoutProps) {
               />
               <Breadcrumb>
                 <BreadcrumbList>
-                  {pathnames.map((value, index) => {
-                    const to = `/${pathnames.slice(0, index + 1).join('/')}`;
-                    const isLast = index === pathnames.length - 1;
-                    return (
-                      <BreadcrumbItem
-                        key={to}
-                        className={isLast ? '' : 'hidden md:block'}
-                        data-testid={`breadcrumb-item-${index}`}
-                      >
-                        {isLast ? (
-                          <BreadcrumbPage aria-current="page">
-                            {value}
-                          </BreadcrumbPage>
-                        ) : (
-                          <BreadcrumbLink>
-                            <Link to={to}>{value}</Link>
-                          </BreadcrumbLink>
-                        )}
-                        {!isLast && (
-                          <BreadcrumbSeparator className="hidden md:block" />
-                        )}
-                      </BreadcrumbItem>
-                    );
-                  })}
+                    {pathnames.map((value, index) => {
+                      const to = `/${pathnames.slice(0, index + 1).join('/')}`;
+                      const isLast = index === pathnames.length - 1;
+                      return (
+                        <Fragment key={to}>
+                          <BreadcrumbItem
+                            className={isLast ? '' : 'hidden md:inline-flex'}
+                            data-testid={`breadcrumb-item-${index}`}
+                          >
+                            {isLast ? (
+                              <BreadcrumbPage aria-current="page">
+                                {value}
+                              </BreadcrumbPage>
+                            ) : (
+                              <BreadcrumbLink asChild>
+                                <Link to={to}>{value}</Link>
+                              </BreadcrumbLink>
+                            )}
+                          </BreadcrumbItem>
+                          {!isLast && (
+                            <BreadcrumbSeparator className="hidden md:block" />
+                          )}
+                        </Fragment>
+                      );
+                    })}
                 </BreadcrumbList>
               </Breadcrumb>
             </div>


### PR DESCRIPTION
## Summary
Improve the component catalog discoverability UI and clarify monorepo-targeted registry install guidance.

## What changed
- add URL-driven search, category filters, and use-case filters to the component index
- add browse-by-use-case cards, visible-count feedback, and an empty-state/reset path for the catalog
- expand the component metadata and tests that drive the new filtering behaviour
- refine the shell layout breadcrumb rendering to use the updated shadcn breadcrumb composition cleanly
- update consumer-facing registry install docs to show a copy-safe monorepo `-c path/to/workspace` example

## Why
The issue 98 docs additions are present, but they are hard to find by task or screen type without better browsing and filtering. At the same time, the registry docs should show a monorepo install command that is accurate for downstream consumers instead of implying a repo-specific path.

## Verification
- `pnpm run type-check:client`
- focused `ComponentIndex.test.tsx` run passed
- markdown diagnostics clean for the touched registry/install docs
